### PR TITLE
docs: extend manifest staleness matrix with Missing and Untracked states

### DIFF
--- a/docs/decisions/ASSEMBLY-0003 Manifest-Based Deployment Tracking.md
+++ b/docs/decisions/ASSEMBLY-0003 Manifest-Based Deployment Tracking.md
@@ -69,8 +69,10 @@ On subsequent installs, copy reads `.manifest` from the target and compares:
 | -------------------------- | ------------------------- | --------- | ------------------- |
 | matches                    | matches                   | Unchanged | skip                |
 | matches                    | differs                   | Stale     | copy (safe)         |
-| differs                    | —                         | Modified  | skip (or `--force`) |
-| not in `.manifest`         | —                         | New       | copy                |
+| differs                    | any                       | Modified  | skip (or `--force`) |
+| not in `.manifest`         | any                       | New       | copy                |
+| in `.manifest`             | not on disk               | Missing   | investigate         |
+| on disk                    | not in `.manifest`        | Untracked | flag unexpected     |
 
 Source-level staleness (has the source changed since last build?) is detected by comparing provenance sidecars against current source files. See ASSEMBLY-0002.
 


### PR DESCRIPTION
## Summary
- Extends the file-staleness comparison table in ASSEMBLY-0003 with two new tracking states: **Missing** (in manifest but absent from disk) and **Untracked** (on disk but not in manifest)
- Clarifies existing column values by replacing `—` with `any` for consistency

## Test plan
- [ ] Review the updated table in the rendered markdown for correctness and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>