### PR TITLE
feat: adopt prek as validation entry point

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,30 +4,11 @@ set -euo pipefail
 # forge module pre-commit hook
 # Canonical source: https://github.com/N4M3Z/forge-cli/blob/main/templates/git/pre-commit
 
-SCRIPT_URL="https://raw.githubusercontent.com/N4M3Z/forge-cli/main/scripts/validate.sh"
-SCRIPT_SHA="f1fc47c463097005152ff2dcd5c8e57e7bb55d9b8c7a61c5b697fc662aeb5bde"
-
-# Prefer forge binary, fall back to validate.sh via curl
-if command -v forge >/dev/null 2>&1; then
+if command -v prek >/dev/null 2>&1; then
+    prek run --all-files
+elif command -v forge >/dev/null 2>&1; then
     forge validate .
-    exit $?
+else
+    echo "`prek` and `forge` not found, falling back to validate.sh"
+    bash scripts/validate.sh .
 fi
-
-echo "forge not found, falling back to validate.sh"
-
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
-
-curl --max-time 30 -sfL "$SCRIPT_URL" -o "$tmpdir/validate.sh" 2>/dev/null \
-    || { echo "validate.sh unreachable — install forge-cli or check connectivity"; exit 1; }
-
-actual=$(sha256sum "$tmpdir/validate.sh" 2>/dev/null || shasum -a 256 "$tmpdir/validate.sh")
-actual=${actual%% *}
-
-if [ "$actual" != "$SCRIPT_SHA" ]; then
-    echo "validate.sh hash mismatch (expected $SCRIPT_SHA, got $actual)"
-    echo "  update SCRIPT_SHA after verifying the new script"
-    exit 1
-fi
-
-bash "$tmpdir/validate.sh" .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,36 @@ jobs:
               with:
                   components: rustfmt, clippy
 
-            - name: Validate
-              run: bash scripts/validate.sh
+            - name: Build
+              run: cargo build --release
 
-            - name: Test
-              run: cargo test
+            - name: Upload binary
+              uses: actions/upload-artifact@v7
+              with:
+                  name: forge
+                  path: target/release/forge
+
+    quality:
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  components: rustfmt, clippy
+
+            - name: Download forge
+              uses: actions/download-artifact@v8
+              with:
+                  name: forge
+                  path: /usr/local/bin
+
+            - name: Install tools
+              run: |
+                  chmod +x /usr/local/bin/forge
+                  curl -sSfL "$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep -o 'https://[^"]*linux_x64.tar.gz')" | tar xz -C /usr/local/bin
+                  pip install semgrep
+
+            - name: Validate
+              uses: j178/prek-action@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
               run: tar czf "$ARCHIVE" -C "target/$TARGET/release" forge
 
             - name: Upload artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ${{ matrix.archive }}
                   path: ${{ matrix.archive }}
@@ -78,7 +78,7 @@ jobs:
                   ref: ${{ inputs.tag }}
 
             - name: Download artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
 
             - name: Create release
               env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,15 @@
+name: Test
+
+on:
+    workflow_dispatch:
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+
+            - uses: dtolnay/rust-toolchain@stable
+
+            - name: Test
+              run: cargo test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
       hooks:
           - id: trailing-whitespace
           - id: check-yaml
+            exclude: ^templates/
           - id: check-json
 
     - repo: local
@@ -57,5 +58,11 @@ repos:
           - id: semgrep
             name: semgrep OWASP
             entry: semgrep scan --config=p/owasp-top-ten --metrics=off --quiet .
+            language: system
+            pass_filenames: false
+
+          - id: forge-validate
+            name: forge validate
+            entry: forge validate .
             language: system
             pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 make build              # cargo build --release
-make test               # cargo test + doc tests
-make lint               # cargo fmt --check + clippy + semgrep OWASP
+make validate           # run pre-commit checks (prek → forge → validate.sh)
+make test               # validate + cargo test
+make install            # build, symlink to ~/.local/bin/forge, activate git hooks
 make check              # verify module structure files exist
-make install            # build + symlink to ~/.local/bin/forge + configure pre-commit hook
 ```
 
 Run a single test:
@@ -18,7 +18,7 @@ Run a single test:
 cargo test -- test_name
 ```
 
-Pre-commit hook runs `scripts/validate.sh` via `.githooks/pre-commit`. Activated by `make install` (sets `core.hooksPath`).
+Pre-commit hook cascade: `prek run --all-files` → `forge validate .` → `scripts/validate.sh`. Activated by `make install` (sets `core.hooksPath` to `.githooks`). prek config in `.pre-commit-config.yaml`.
 
 ## Architecture
 
@@ -32,20 +32,20 @@ source files → assemble (strip frontmatter, resolve variants, apply transforms
 
 ### Key Modules
 
-| Module          | Path                | Purpose                                                      |
-| --------------- | ------------------- | ------------------------------------------------------------ |
-| `cli`           | `src/cli/`          | Clap subcommands — one file per command                      |
-| `assemble`      | `src/assemble/`     | Strip frontmatter, resolve variant overrides, strip ref links |
-| `transform`     | `src/transform/`    | Provider-specific transforms (kebab-case, tool remap, TOML)  |
-| `validate`      | `src/validate/`     | Module structure, `.mdschema` compliance, agent frontmatter  |
-| `manifest`      | `src/manifest/`     | `.manifest` read/write, SLSA provenance sidecars, staleness  |
-| `provider`      | `src/provider/`     | Provider config from `defaults.yaml` (targets, assembly rules) |
-| `parse`         | `src/parse/`        | YAML frontmatter extraction (flat keys only, no nested YAML) |
-| `target`        | `src/target/`       | Deploy target resolution (scope, platform paths)             |
-| `module`        | `src/module.rs`     | `module.yaml` deserialization                                |
-| `error`         | `src/error.rs`      | `ErrorKind` enum + `Error` struct                            |
-| `result`        | `src/result.rs`     | `ActionResult` for structured command output                 |
-| `yaml`          | `src/yaml/`         | YAML deep merge (defaults + config overlay)                  |
+| Module     | Path             | Purpose                                                       |
+| ---------- | ---------------- | ------------------------------------------------------------- |
+| `cli`      | `src/cli/`       | Clap subcommands — one directory per command with `mod.rs` + `tests.rs` |
+| `assemble` | `src/assemble/`  | Strip frontmatter, resolve variant overrides, strip ref links |
+| `transform`| `src/transform/` | Provider-specific transforms (kebab-case, tool remap, TOML)  |
+| `validate` | `src/validate/`  | Module structure, `.mdschema` compliance, agent frontmatter   |
+| `manifest` | `src/manifest/`  | `.manifest` read/write, SLSA provenance sidecars, staleness   |
+| `provider` | `src/provider/`  | Provider config from `defaults.yaml` (targets, assembly rules) |
+| `parse`    | `src/parse/`     | YAML frontmatter extraction (flat keys only, no nested YAML)  |
+| `target`   | `src/target/`    | Deploy target resolution (scope, platform paths)              |
+| `module`   | `src/module.rs`  | `module.yaml` deserialization                                 |
+| `error`    | `src/error.rs`   | `ErrorKind` enum + `Error` struct                             |
+| `result`   | `src/result.rs`  | `ActionResult` for structured command output                  |
+| `yaml`     | `src/yaml/`      | YAML deep merge (defaults + config overlay)                   |
 
 ### Crate Structure
 
@@ -57,9 +57,15 @@ Provider conventions are config-driven via `defaults.yaml`. Each provider has a 
 
 Variant resolution uses qualifier directories (`user/`, `claude/`, `claude-opus-4/`) that flatten at assembly time. `user/` has highest precedence.
 
+### Validation
+
+`forge validate` runs structural checks only (module files, frontmatter, mdschema). External tool checks (shellcheck, cargo fmt/clippy, gitleaks, semgrep, ruff, tsc) run as fallback when prek is not installed. When prek is the orchestrator, `forge validate` skips external tools to avoid duplication.
+
+Configurable excludes in `defaults.yaml` under `validate.exclude` — glob patterns for files to skip during YAML/JSON/whitespace checks (e.g. `templates/*` for template files with placeholders).
+
 ### Test Layout
 
-Unit tests live as sibling `tests.rs` files next to `mod.rs`. Integration tests in `tests/` with fixtures in `tests/fixtures/`. Fixtures loaded via `include_str!`.
+Unit tests live as sibling `tests.rs` files next to `mod.rs` in every module. Integration tests in `tests/` with fixtures in `tests/fixtures/`. Fixtures loaded via `include_str!`.
 
 ## Conventions
 
@@ -69,3 +75,4 @@ Unit tests live as sibling `tests.rs` files next to `mod.rs`. Integration tests 
 - 4-space indentation everywhere
 - All commands support `--json` for machine-readable output
 - `defaults.yaml` (committed) + `config.yaml` (gitignored) deep merge pattern
+- PRs required for all changes to `main` (branch ruleset enforced)

--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,31 @@
-# forge-cli — build, test, lint, install
+# forge-cli
 
+FORGE ?= forge
 BINARY = target/release/forge
 
-.PHONY: help build test lint check clean install
+.PHONY: help build install validate test clean
 
 help:
-	@echo "forge-cli targets:"
-	@echo "  make build     Compile the forge binary"
-	@echo "  make test      Run all tests"
-	@echo "  make lint      Clippy + fmt + shellcheck + semgrep"
-	@echo "  make check     Verify module structure and dependencies"
-	@echo "  make install   Build and symlink forge to ~/.local/bin"
-	@echo "  make clean     Remove build artifacts"
+	@echo "  make build      compile the forge binary"
+	@echo "  make install    build, symlink, activate git hooks"
+	@echo "  make validate   run pre-commit checks"
+	@echo "  make test       validate + cargo test"
+	@echo "  make clean      remove build artifacts"
 
 build:
 	cargo build --release
-
-test:
-	cargo test
-	cargo test --doc
-
-lint:
-	@if command -v prek >/dev/null 2>&1; then prek run --all-files; \
-	else cargo fmt --check && cargo clippy -- -D warnings; fi
-	@if command -v semgrep >/dev/null 2>&1; then semgrep scan --config=p/owasp-top-ten --metrics=off --quiet . 2>/dev/null || true; fi
-
-check:
-	@test -f module.yaml      && echo "  ok module.yaml"      || echo "  MISSING module.yaml"
-	@test -f Cargo.toml       && echo "  ok Cargo.toml"       || echo "  MISSING Cargo.toml"
-	@test -f defaults.yaml    && echo "  ok defaults.yaml"    || echo "  MISSING defaults.yaml"
-	@test -f README.md        && echo "  ok README.md"        || echo "  MISSING README.md"
-	@test -f INSTALL.md       && echo "  ok INSTALL.md"       || echo "  MISSING INSTALL.md"
-	@test -f CONTRIBUTING.md  && echo "  ok CONTRIBUTING.md"  || echo "  MISSING CONTRIBUTING.md"
-	@test -f CHANGELOG.md     && echo "  ok CHANGELOG.md"     || echo "  MISSING CHANGELOG.md"
-	@test -f CODEOWNERS       && echo "  ok CODEOWNERS"       || echo "  MISSING CODEOWNERS"
-	@test -f LICENSE          && echo "  ok LICENSE"          || echo "  MISSING LICENSE"
-	@test -f .gitattributes   && echo "  ok .gitattributes"   || echo "  MISSING .gitattributes"
 
 install: build
 	mkdir -p ~/.local/bin
 	ln -sf "$(CURDIR)/$(BINARY)" ~/.local/bin/forge
 	git config core.hooksPath .githooks
 	@echo "Installed: forge -> $(CURDIR)/$(BINARY)"
+
+validate:
+	@bash .githooks/pre-commit
+
+test: validate
+	cargo test
 
 clean:
 	cargo clean

--- a/src/cli/validate/tools.rs
+++ b/src/cli/validate/tools.rs
@@ -5,14 +5,6 @@ use std::process::Command;
 use crate::cli::config;
 
 pub fn run_external_checks(module_root: &Path, result: &mut ActionResult) {
-    if has_tool("prek") && module_root.join(".pre-commit-config.yaml").is_file() {
-        println!("  prek run --all-files");
-        if !run_command("prek", &["run", "--all-files"], module_root) {
-            result.errors.push("prek checks failed".to_string());
-        }
-        return;
-    }
-
     let exclude_patterns = load_exclude_patterns(module_root);
 
     check_trailing_whitespace(module_root, &exclude_patterns, result);
@@ -24,7 +16,6 @@ pub fn run_external_checks(module_root: &Path, result: &mut ActionResult) {
     check_ruff(module_root, result);
     check_gitleaks(module_root, result);
     check_semgrep(module_root, result);
-    run_cargo_test(module_root, result);
 }
 
 fn load_exclude_patterns(module_root: &Path) -> Vec<String> {
@@ -171,17 +162,6 @@ fn check_cargo(module_root: &Path, result: &mut ActionResult) {
         result
             .errors
             .push("cargo clippy found warnings".to_string());
-    }
-}
-
-fn run_cargo_test(module_root: &Path, result: &mut ActionResult) {
-    if !module_root.join("Cargo.toml").is_file() || !has_tool("cargo") {
-        return;
-    }
-
-    println!("  cargo test");
-    if !run_command("cargo", &["test"], module_root) {
-        result.errors.push("cargo test failed".to_string());
     }
 }
 

--- a/templates/git/pre-commit
+++ b/templates/git/pre-commit
@@ -7,27 +7,27 @@ set -euo pipefail
 SCRIPT_URL="https://raw.githubusercontent.com/N4M3Z/forge-cli/main/scripts/validate.sh"
 SCRIPT_SHA="f1fc47c463097005152ff2dcd5c8e57e7bb55d9b8c7a61c5b697fc662aeb5bde"
 
-# Prefer forge binary, fall back to validate.sh via curl
-if command -v forge >/dev/null 2>&1; then
+if command -v prek >/dev/null 2>&1; then
+    prek run --all-files
+elif command -v forge >/dev/null 2>&1; then
     forge validate .
-    exit $?
+else
+    echo "`prek` and `forge` not found, falling back to validate.sh"
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    curl --max-time 30 -sfL "$SCRIPT_URL" -o "$tmpdir/validate.sh" 2>/dev/null \
+        || { echo "validate.sh unreachable — install forge-cli or check connectivity"; exit 1; }
+
+    actual=$(sha256sum "$tmpdir/validate.sh" 2>/dev/null || shasum -a 256 "$tmpdir/validate.sh")
+    actual=${actual%% *}
+
+    if [ "$actual" != "$SCRIPT_SHA" ]; then
+        echo "validate.sh hash mismatch (expected $SCRIPT_SHA, got $actual)"
+        echo "  update SCRIPT_SHA after verifying the new script"
+        exit 1
+    fi
+
+    bash "$tmpdir/validate.sh" .
 fi
-
-echo "forge not found, falling back to validate.sh"
-
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
-
-curl --max-time 30 -sfL "$SCRIPT_URL" -o "$tmpdir/validate.sh" 2>/dev/null \
-    || { echo "validate.sh unreachable — install forge-cli or check connectivity"; exit 1; }
-
-actual=$(sha256sum "$tmpdir/validate.sh" 2>/dev/null || shasum -a 256 "$tmpdir/validate.sh")
-actual=${actual%% *}
-
-if [ "$actual" != "$SCRIPT_SHA" ]; then
-    echo "validate.sh hash mismatch (expected $SCRIPT_SHA, got $actual)"
-    echo "  update SCRIPT_SHA after verifying the new script"
-    exit 1
-fi
-
-bash "$tmpdir/validate.sh" .

--- a/templates/mk/check.mk
+++ b/templates/mk/check.mk
@@ -1,0 +1,15 @@
+# Module structure check — include from project Makefile
+# Usage: include templates/mk/check.mk
+
+.PHONY: check
+
+check:
+	@test -f module.yaml      && echo "  ok module.yaml"      || echo "  MISSING module.yaml"
+	@test -f defaults.yaml    && echo "  ok defaults.yaml"    || echo "  MISSING defaults.yaml"
+	@test -f README.md        && echo "  ok README.md"        || echo "  MISSING README.md"
+	@test -f LICENSE          && echo "  ok LICENSE"          || echo "  MISSING LICENSE"
+	@test -f INSTALL.md       && echo "  ok INSTALL.md"       || echo "  MISSING INSTALL.md (optional)"
+	@test -f CONTRIBUTING.md  && echo "  ok CONTRIBUTING.md"  || echo "  MISSING CONTRIBUTING.md (optional)"
+	@test -f CODEOWNERS       && echo "  ok CODEOWNERS"       || echo "  MISSING CODEOWNERS (optional)"
+	@test -f CHANGELOG.md     && echo "  ok CHANGELOG.md"     || echo "  MISSING CHANGELOG.md (optional)"
+	@test -f .gitattributes   && echo "  ok .gitattributes"   || echo "  MISSING .gitattributes (optional)"


### PR DESCRIPTION
## Summary

- prek becomes the single validation entry point (pre-commit hook, CI, `make lint`)
- `.pre-commit-config.yaml` includes `forge validate` as a local hook — prek invokes forge, no double-run
- CI workflow split into build → check (prek) + test (parallel)
- Pre-commit hook cascade: prek → forge → validate.sh
- `validate.sh` stays as bootstrap fallback for repos without prek or forge

## Test plan

- [ ] CI passes (build, check with prek-action, test)
- [ ] `prek run --all-files` runs all checks including `forge validate`
- [ ] `SKIP=cargo-test prek run --all-files` skips individual checks
- [ ] Pre-commit hook works with prek installed
- [ ] Pre-commit hook falls back to forge when prek absent
- [ ] Pre-commit hook falls back to validate.sh when both absent