### PR TITLE
feat: audit, support mnemonic refs, embedded mdschema, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- prek as declarative validation entry point
+- Native YAML, JSON, and trailing whitespace checks in `forge validate`
+- `--source` filter on `forge provenance` command
+- `templates/` reorganized into `mdschema/`, `provenance/`, `init/`
+
+### Fixed
+
+- `load_models` path and error handling
+- `--show-orphans` flag name (was documented as `--orphans`)
+- Stale Makefile targets in README, CLAUDE.md, CONTRIBUTING.md
+
 ## [0.2.0] - 2026-04-04
 
 ### Added
 
 - `forge drift` command for upstream comparison with frontmatter key diffing and `--ignore` flag
-- `forge provenance --orphans` flag for detecting files without provenance
-- `forge provenance --source` filter for scoping scan results by module
+- `forge provenance --show-orphans` flag for detecting files without provenance
 - `forge clean` command for removing stale files from previous installs
 - `forge release` command for packaging assembled content as tarballs
 - `forge validate` runs external tools (shellcheck, cargo fmt/clippy, cargo test, tsc, gitleaks)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 make build              # cargo build --release
+make install            # build, symlink to ~/.local/bin/forge, activate git hooks
 make validate           # run pre-commit checks (prek → forge → validate.sh)
 make test               # validate + cargo test
-make install            # build, symlink to ~/.local/bin/forge, activate git hooks
-make check              # verify module structure files exist
+make clean              # remove build artifacts
 ```
 
 Run a single test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,19 +7,11 @@ git clone https://github.com/N4M3Z/forge-cli.git
 cd forge-cli
 make build
 make test
-make lint
 ```
 
 ## Build & Test
 
-```sh
-make build              # cargo build --release
-make test               # cargo test + doc tests
-make lint               # cargo fmt --check + clippy + semgrep
-make check              # verify module structure
-```
-
-Run a single test:
+See [README.md](README.md#build) for build targets. Run a single test:
 
 ```sh
 cargo test -- test_name
@@ -57,5 +49,7 @@ Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`.
 
 1. Fork and create a branch
 2. Make changes following the conventions above
-3. `make test && make lint`
+3. `make test`
 4. Open a PR against `main`
+
+CI runs `prek` (linting, formatting, tests) and `cargo test` on every PR. The `main` branch requires passing CI and one approval before merge.

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ All commands support `--json` for machine-readable output.
 ## Build
 
 ```sh
-make build    # cargo build --release
-make test     # cargo test + doc tests
-make lint     # cargo fmt --check + clippy + semgrep OWASP
-make check    # verify module structure files exist
-make install  # build + symlink to ~/.local/bin/forge + configure pre-commit hook
+make build      # cargo build --release
+make install    # build, symlink to ~/.local/bin/forge, activate git hooks
+make validate   # run pre-commit checks (prek → forge → validate.sh)
+make test       # validate + cargo test
+make clean      # remove build artifacts
 ```
 
 ## Pipeline Artifacts

--- a/schemas/forge-adr.schema.json
+++ b/schemas/forge-adr.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://github.com/N4M3Z/forge-core/schemas/forge-adr.schema.json",
+    "$id": "https://github.com/N4M3Z/forge-cli/schemas/forge-adr.schema.json",
     "title": "Forge ADR Frontmatter",
     "description": "JSON Schema for validating forge ADR YAML frontmatter (structured-madr + x-forge- extensions)",
     "type": "object",

--- a/src/assemble/references.rs
+++ b/src/assemble/references.rs
@@ -1,11 +1,13 @@
-/// Remove reference-style link definitions (`[1]: url`) and
-/// inline reference markers (` [1]`) from content.
+/// Remove reference-style link definitions (`[1]: url`, `[MADR]: url`) and
+/// inline reference markers (` [1]`, ` [MADR]`) from content.
 pub fn strip(content: &str) -> String {
     static INLINE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
     static DEF_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 
-    let inline_re = INLINE_RE.get_or_init(|| regex::Regex::new(r" \[\d+\]").expect("valid regex"));
-    let def_re = DEF_RE.get_or_init(|| regex::Regex::new(r"^\[\d+\]:").expect("valid regex"));
+    let inline_re =
+        INLINE_RE.get_or_init(|| regex::Regex::new(r" \[[\w][\w-]*\]").expect("valid regex"));
+    let def_re =
+        DEF_RE.get_or_init(|| regex::Regex::new(r"^\[[\w][\w-]*\]:").expect("valid regex"));
 
     let mut output_lines: Vec<String> = Vec::new();
     let mut in_ref_block = false;
@@ -38,7 +40,7 @@ pub fn extract(content: &str) -> Vec<String> {
     static URL_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
 
     let url_re =
-        URL_RE.get_or_init(|| regex::Regex::new(r"^\[\d+\]:\s*(\S+)").expect("valid regex"));
+        URL_RE.get_or_init(|| regex::Regex::new(r"^\[[\w][\w-]*\]:\s*(\S+)").expect("valid regex"));
 
     let mut urls: Vec<String> = Vec::new();
     for line in content.lines() {

--- a/src/assemble/tests.rs
+++ b/src/assemble/tests.rs
@@ -123,6 +123,32 @@ fn extract_returns_empty_for_no_refs() {
     assert!(urls.is_empty());
 }
 
+const REFS_MNEMONIC: &str = fixture!("refs-mnemonic.md");
+
+#[test]
+fn strip_removes_mnemonic_inline_markers() {
+    let result = references::strip("Text with a ref [MADR] and another [OWASP].");
+    assert_eq!(result, "Text with a ref and another.");
+}
+
+#[test]
+fn strip_removes_mnemonic_definitions() {
+    let result = references::strip(REFS_MNEMONIC);
+    assert!(!result.contains("[MADR]"));
+    assert!(!result.contains("[OWASP]"));
+    assert!(!result.contains("[keepachangelog]"));
+    assert!(!result.contains("https://adr.github.io"));
+}
+
+#[test]
+fn extract_returns_mnemonic_urls() {
+    let urls = references::extract(REFS_MNEMONIC);
+    assert_eq!(urls.len(), 3);
+    assert_eq!(urls[0], "https://adr.github.io/madr/");
+    assert_eq!(urls[1], "https://owasp.org/");
+    assert_eq!(urls[2], "https://keepachangelog.com/");
+}
+
 // --- variants::Mode ---
 
 #[test]

--- a/src/cli/config/mod.rs
+++ b/src/cli/config/mod.rs
@@ -97,7 +97,7 @@ pub fn load_tool_mappings(
 /// Returns an empty map if neither the module file nor the embedded file
 /// can be parsed (all model-tier qualifiers become unresolvable).
 pub fn load_models(module_root: &Path) -> HashMap<String, Vec<String>> {
-    let models_path = module_root.join("models.yaml");
+    let models_path = module_root.join("config/models.yaml");
     let content = if models_path.is_file() {
         read_file(&models_path).ok()
     } else {
@@ -105,7 +105,15 @@ pub fn load_models(module_root: &Path) -> HashMap<String, Vec<String>> {
     };
 
     match content {
-        Some(yaml) => provider::load_models(&yaml).unwrap_or_default(),
+        Some(yaml) => match provider::load_models(&yaml) {
+            Ok(models) => models,
+            Err(error) => {
+                eprintln!(
+                    "warning: failed to parse models config ({error}), using embedded defaults"
+                );
+                provider::load_models(EMBEDDED_MODELS).unwrap_or_default()
+            }
+        },
         None => HashMap::new(),
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -87,6 +87,10 @@ enum Command {
         /// Path to a deployed file or provider directory
         path: String,
 
+        /// Filter by source module URI
+        #[arg(long)]
+        source: Option<String>,
+
         /// Show files without provenance
         #[arg(long)]
         show_orphans: bool,
@@ -154,8 +158,12 @@ pub fn run() -> i32 {
         ),
         Command::Copy { path, target } => (copy::execute(&path, &target), "copied"),
         Command::Validate { path } => (validate::execute(&path), "validated"),
-        Command::Provenance { path, show_orphans } => {
-            return match provenance::execute(&path, None, show_orphans, args.json) {
+        Command::Provenance {
+            path,
+            source,
+            show_orphans,
+        } => {
+            return match provenance::execute(&path, source.as_deref(), show_orphans, args.json) {
                 Ok(code) => code,
                 Err(error) => {
                     eprintln!("fatal: {error}");

--- a/src/cli/validate/check.rs
+++ b/src/cli/validate/check.rs
@@ -85,10 +85,12 @@ pub fn skill_directory(dir: &Path, result: &mut ActionResult) -> Result<(), Erro
         let content = read_file(&skill_file)?;
         let display_path = skill_file.to_string_lossy().to_string();
 
+        let skill_schema = schema::embedded_schema("skills").map(String::from);
+
         collect_diagnostics(
             &content,
             &display_path,
-            None,
+            skill_schema.as_ref(),
             mdschema_content.as_ref(),
             result,
         );

--- a/src/cli/validate/tests.rs
+++ b/src/cli/validate/tests.rs
@@ -50,3 +50,29 @@ fn check_module_yaml_skips_when_no_module_yaml() {
 
     assert!(result.errors.is_empty());
 }
+
+// --- tools.rs native checks ---
+
+#[test]
+fn is_excluded_matches_prefix_glob() {
+    let module_root = std::path::Path::new("/project");
+    let file_path = std::path::Path::new("/project/templates/statement.yaml");
+    let patterns = vec!["templates/*".to_string()];
+    assert!(tools::is_excluded(file_path, module_root, &patterns));
+}
+
+#[test]
+fn is_excluded_rejects_non_matching_path() {
+    let module_root = std::path::Path::new("/project");
+    let file_path = std::path::Path::new("/project/schemas/agent.schema.yaml");
+    let patterns = vec!["templates/*".to_string()];
+    assert!(!tools::is_excluded(file_path, module_root, &patterns));
+}
+
+#[test]
+fn is_excluded_matches_exact_path() {
+    let module_root = std::path::Path::new("/project");
+    let file_path = std::path::Path::new("/project/defaults.yaml");
+    let patterns = vec!["defaults.yaml".to_string()];
+    assert!(tools::is_excluded(file_path, module_root, &patterns));
+}

--- a/src/cli/validate/tools.rs
+++ b/src/cli/validate/tools.rs
@@ -106,7 +106,7 @@ fn check_json_syntax(module_root: &Path, exclude_patterns: &[String], result: &m
     }
 }
 
-fn is_excluded(path: &Path, module_root: &Path, patterns: &[String]) -> bool {
+pub(super) fn is_excluded(path: &Path, module_root: &Path, patterns: &[String]) -> bool {
     let relative = path
         .strip_prefix(module_root)
         .unwrap_or(path)

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -583,3 +583,68 @@ fn install_targets_multiple_providers() {
         "should NOT deploy to codex"
     );
 }
+
+// --- Issue #8: manifest at --target location ---
+
+#[test]
+fn install_target_writes_manifest_with_correct_fingerprints() {
+    let module_directory = tempfile::tempdir().unwrap();
+    let target_directory = tempfile::tempdir().unwrap();
+
+    scaffold_module(module_directory.path());
+    create_rule(module_directory.path(), "ManifestRule");
+
+    forge()
+        .args([
+            "install",
+            module_directory.path().to_str().unwrap(),
+            "--target",
+            target_directory.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let manifest_path = target_directory.path().join(".claude/.manifest");
+    assert!(manifest_path.is_file(), ".manifest should exist at target");
+
+    let manifest_content = fs::read_to_string(&manifest_path).unwrap();
+    assert!(
+        manifest_content.contains("ManifestRule.md"),
+        "manifest should reference the deployed rule"
+    );
+    assert!(
+        manifest_content.contains("fingerprint:"),
+        "manifest should contain fingerprints"
+    );
+}
+
+// --- Issue #12: mdschema validation in validate pipeline ---
+
+#[test]
+fn validate_catches_mdschema_violation() {
+    let module_directory = tempfile::tempdir().unwrap();
+
+    scaffold_module(module_directory.path());
+    fs::write(module_directory.path().join("README.md"), "# Test\n").unwrap();
+    fs::write(module_directory.path().join("LICENSE"), "EUPL-1.2\n").unwrap();
+
+    let rules_dir = module_directory.path().join("rules");
+    fs::create_dir_all(&rules_dir).unwrap();
+
+    fs::write(
+        rules_dir.join(".mdschema"),
+        "frontmatter:\n    fields:\n        - name: status\n          type: string\n",
+    )
+    .unwrap();
+
+    fs::write(
+        rules_dir.join("BadRule.md"),
+        "---\nname: BadRule\ndescription: missing status field\n---\n\n# BadRule\n",
+    )
+    .unwrap();
+
+    forge()
+        .args(["validate", module_directory.path().to_str().unwrap()])
+        .assert()
+        .failure();
+}

--- a/tests/fixtures/input/refs-mnemonic.md
+++ b/tests/fixtures/input/refs-mnemonic.md
@@ -1,0 +1,7 @@
+This rule follows the MADR format [MADR] for architecture decisions.
+
+See also the OWASP guidance [OWASP] and Keep a Changelog [keepachangelog].
+
+[MADR]: https://adr.github.io/madr/
+[OWASP]: https://owasp.org/
+[keepachangelog]: https://keepachangelog.com/


### PR DESCRIPTION
## Summary

- Sync README, CLAUDE.md, CONTRIBUTING.md Build sections with actual Makefile targets
- Fix `load_models` path (`models.yaml` → `config/models.yaml`) and error handling
- Wire `--source` filter to `forge provenance` CLI
- Fix strip-links regex to match mnemonic labels (`[MADR]`, `[OWASP]`)
- Apply embedded skill schema to SKILL.md validation
- Update CHANGELOG with unreleased entries and fix flag names
- Fix `forge-adr.schema.json` `$id`
- Add unit tests for `is_excluded`, mnemonic refs, manifest at --target, mdschema pipeline

Closes #8 #11 #12