### PR TITLE
fix: normalize H1 heading in drift body comparison

### DIFF
--- a/src/assemble/frontmatter.rs
+++ b/src/assemble/frontmatter.rs
@@ -59,7 +59,7 @@ pub fn strip_frontmatter(content: &str, keep_fields: &[&str]) -> String {
 }
 
 /// Strip a leading `# Title` heading if it's the first non-empty line.
-fn strip_heading(text: &str) -> String {
+pub fn strip_heading(text: &str) -> String {
     let mut lines = text.lines();
     let mut skipped_blanks: Vec<&str> = Vec::new();
 

--- a/src/assemble/mod.rs
+++ b/src/assemble/mod.rs
@@ -5,6 +5,7 @@ pub mod references;
 pub mod variants;
 
 pub use frontmatter::strip_frontmatter;
+pub use frontmatter::strip_heading;
 pub use references::{extract, strip};
 pub use variants::{Mode, apply, resolve};
 

--- a/src/cli/drift/mod.rs
+++ b/src/cli/drift/mod.rs
@@ -1,3 +1,4 @@
+use commands::assemble::strip_heading;
 use commands::error::{Error, ErrorKind};
 use commands::manifest::content_sha256;
 use commands::parse::split_frontmatter;
@@ -198,11 +199,22 @@ fn compare_file_content(
     }
 
     let (module_frontmatter, module_body) = split_parts(module_content);
-    let (upstream_frontmatter, upstream_body) = split_parts(upstream_content);
+    let (upstream_frontmatter, raw_upstream_body) = split_parts(upstream_content);
+
+    // Assembly strips the leading `# Title` heading from deployed files.
+    // Normalize both sides through the same transformation so drift
+    // only fires on real content changes, not assembly artifacts.
+    // This intentionally makes heading-only differences invisible —
+    // including heading renames (e.g., `# OldName` → `# NewName`) —
+    // because headings are derived from the `name` frontmatter field
+    // during assembly, not authored body content.
+    let normalized_upstream_body = strip_heading(raw_upstream_body);
+    let normalized_module_body = strip_heading(module_body);
 
     let frontmatter_match =
         content_sha256(module_frontmatter) == content_sha256(upstream_frontmatter);
-    let body_match = content_sha256(module_body) == content_sha256(upstream_body);
+    let body_match =
+        content_sha256(&normalized_module_body) == content_sha256(&normalized_upstream_body);
 
     let changed_keys = if frontmatter_match {
         Vec::new()

--- a/src/cli/drift/tests.rs
+++ b/src/cli/drift/tests.rs
@@ -136,6 +136,53 @@ fn parse_top_level_keys_returns_empty_for_invalid_yaml() {
 }
 
 #[test]
+fn compare_file_content_h1_heading_stripped_is_not_drift() {
+    // Upstream has H1 heading, deployed (module) has it stripped by assembly.
+    // Drift should NOT report body drift for this.
+    let module_content = "---\nname: test\n---\nBody after heading.";
+    let upstream_content = "---\nname: test\n---\n# TestSkill\nBody after heading.";
+    let entry = compare_file_content(
+        "SKILL.md",
+        module_content,
+        upstream_content,
+        "skills",
+        &HashSet::new(),
+    );
+    assert_eq!(entry.status, DriftStatus::Identical);
+}
+
+#[test]
+fn compare_file_content_h1_rename_is_invisible_to_drift() {
+    // Heading renames are intentionally invisible: headings are assembly
+    // artifacts derived from the `name` frontmatter field, not authored content.
+    let module_content = "---\nname: test\n---\n# OldName\nSame body.";
+    let upstream_content = "---\nname: test\n---\n# NewName\nSame body.";
+    let entry = compare_file_content(
+        "SKILL.md",
+        module_content,
+        upstream_content,
+        "skills",
+        &HashSet::new(),
+    );
+    assert_eq!(entry.status, DriftStatus::Identical);
+}
+
+#[test]
+fn compare_file_content_h1_stripped_but_body_modified_is_drift() {
+    // Heading normalization must NOT mask real body changes.
+    let module_content = "---\nname: test\n---\nModified body.";
+    let upstream_content = "---\nname: test\n---\n# TestSkill\nOriginal body.";
+    let entry = compare_file_content(
+        "SKILL.md",
+        module_content,
+        upstream_content,
+        "skills",
+        &HashSet::new(),
+    );
+    assert_eq!(entry.status, DriftStatus::BodyOnly);
+}
+
+#[test]
 fn collect_markdown_files_returns_empty_for_missing_directory() {
     let files = collect_markdown_files(Path::new("/nonexistent"));
     assert!(files.is_empty());


### PR DESCRIPTION
## Summary

- Assembly strips the leading `# Title` heading from deployed files via `strip_heading()`, but `forge drift` compared the raw upstream body (with heading) against the deployed body (without heading)
- This caused every skill file to report `body ⚡ drifted` immediately after a fresh install — 6/6 skills showed false-positive drift
- Fix normalizes both sides through `strip_heading()` before hashing in `compare_file_content()`, so drift only fires on real content changes

## Changes

| File | What |
|------|------|
| `src/assemble/frontmatter.rs` | Make `strip_heading()` pub |
| `src/assemble/mod.rs` | Re-export `strip_heading` |
| `src/cli/drift/mod.rs` | Normalize both bodies through `strip_heading()` before comparing |
| `src/cli/drift/tests.rs` | 2 new tests: H1-stripped identical, H1-stripped with real body drift |

## Test plan

- [x] All 368 existing tests pass (`cargo test`)
- [x] End-to-end: `forge install` + `forge drift` on forge-council — all 6 skills now show `✓ identical` (was 6/6 `body ⚡ drifted`)
- [x] All 19 agents show `body ✓`
- [x] Only expected frontmatter drift remains (`version` on agents, `paths` on rules)

## Related

- Builds on top of #20 (trailing newline fix) — independent branch, no dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)