### PR TITLE
feat: release outputs to dist/ with .manifest

### DIFF
--- a/docs/decisions/ASSEMBLY-0002 Provenance Tracking.md
+++ b/docs/decisions/ASSEMBLY-0002 Provenance Tracking.md
@@ -9,7 +9,7 @@ tags:
     - tracking
 status: accepted
 created: 2026-03-23
-updated: 2026-03-23
+updated: 2026-04-17
 author: "@N4M3Z"
 project: forge-cli
 related:
@@ -44,9 +44,15 @@ When source files are transformed during assembly (frontmatter stripped, variant
 
 Chosen option: **in-toto/SLSA v1.0**, serialized as YAML. in-toto is the industry standard for build provenance [1], purpose-built for tracking "these inputs were transformed into this output by this builder." SLSA builds on in-toto with a structured `buildDefinition` that captures resolved dependencies with per-file digests [2].
 
-Provenance is a **build record** — it answers "what sources produced this built file?" Each assembled file in `build/` gets a `.yaml` sidecar containing the SLSA statement. Sidecars stay in `build/` and are never deployed to the target.
+Provenance is a **build record** — it answers "what sources produced this built file?" Each assembled file in `build/` gets a `.yaml` sidecar containing the SLSA statement.
+
+Sidecars deploy alongside content to per-directory `.provenance/` subdirectories at the target (e.g., `~/.claude/agents/.provenance/SystemArchitect.yaml`). The `.manifest` references each sidecar via its `provenance` field. `forge provenance` reads these to verify deployed integrity.
 
 Source-level staleness detection reads provenance sidecars to compare recorded source hashes against current source files. Deployment-level staleness is handled separately by `.manifest` at the target (see ASSEMBLY-0003).
+
+### Release tarballs
+
+`forge release` reuses install, so `.provenance/` subdirectories ship inside release tarballs alongside `.manifest`. Extracted tarballs preserve the full source-to-output chain, enabling `forge provenance` to verify a tarball's contents without re-running assembly.
 
 ```yaml
 _type: https://in-toto.io/Statement/v1
@@ -82,7 +88,7 @@ For standardized in-toto `.link` attestations, `in-toto-run` can wrap `forge ass
 - [+] Compact — one self-contained statement per output file
 - [+] Source hashes enable source-level staleness detection
 - [+] YAML serialization consistent with ecosystem
-- [+] Sidecars stay in build/ — no context pollution at target
+- [+] Sidecars deploy to `.provenance/` subdirs — referenced by `.manifest`, used by `forge provenance`
 - [-] in-toto envelope adds structural overhead vs flat hashes
 
 ## More Information

--- a/docs/decisions/ASSEMBLY-0003 Manifest-Based Deployment Tracking.md
+++ b/docs/decisions/ASSEMBLY-0003 Manifest-Based Deployment Tracking.md
@@ -9,7 +9,7 @@ tags:
     - deployment
 status: accepted
 created: 2026-03-23
-updated: 2026-04-04
+updated: 2026-04-17
 author: "@N4M3Z"
 project: forge-cli
 related:
@@ -74,10 +74,15 @@ On subsequent installs, copy reads `.manifest` from the target and compares:
 
 Source-level staleness (has the source changed since last build?) is detected by comparing provenance sidecars against current source files. See ASSEMBLY-0002.
 
+### Release tarballs
+
+`forge release` reuses install to stage content, so each provider's `.manifest` lands inside the release tarball at `.{provider}/.manifest`. When end users extract a tarball and `make install`, the manifest copies to `~/.{provider}/.manifest` — exactly where install would have placed it. Round-trip consistent: a tarball is byte-identical to a fresh install of the same module version.
+
 ## Consequences
 
 - [+] Simple format — nested YAML with `fingerprint` and `provenance`, human-readable
 - [+] Lives at the target — survives `build/` cleanup
 - [+] Per-provider — each target directory tracks its own deployments
 - [+] No spec overhead — this is not an attestation, just a cache
+- [+] Ships inside release tarballs — `forge provenance` works against extracted tarballs
 - [-] Manifest corruption means full reinstall (acceptable risk)

--- a/docs/decisions/CLI-0002 Module Layout.md
+++ b/docs/decisions/CLI-0002 Module Layout.md
@@ -8,7 +8,7 @@ tags:
     - architecture
 status: accepted
 created: 2026-03-19
-updated: 2026-04-04
+updated: 2026-04-17
 author: "@N4M3Z"
 project: forge-cli
 related:
@@ -63,16 +63,16 @@ src/
 
     cli/                CLI command handlers (binary-only, owns I/O)
         mod.rs          clap definitions, dispatch
-        install.rs      assemble + deploy
+        install/        assemble + deploy
         assemble/       assembly orchestration (sources, pipeline, provenance, output)
-        deploy.rs       build/ → provider dirs with manifest tracking
-        copy.rs         raw source → target (no assembly)
+        deploy/         build/ → provider dirs with manifest tracking
+        copy/           raw source → target (no assembly)
         validate/       structure + mdschema + external tools
-        drift.rs        upstream comparison with frontmatter key diffing
+        drift/          upstream comparison with frontmatter key diffing
         provenance/     provenance chain display and directory scanning
-        release.rs      assemble + package tarballs
-        config.rs       module config loading and merging
-        output.rs       turbo-style CLI output formatting
+        release/        install to staging + package tarballs in dist/
+        config/         module config loading and merging
+        output/         turbo-style CLI output formatting
 
 tests/
     fixtures/

--- a/src/cli/release/mod.rs
+++ b/src/cli/release/mod.rs
@@ -1,64 +1,84 @@
 use commands::error::{Error, ErrorKind};
+use commands::module;
 use commands::result::{ActionResult, DeployedFile};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use super::assemble;
+use super::install;
 use crate::cli::config;
-use commands::module;
 
 const MAKEFILE_TEMPLATE: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/templates/make/dist.mk"
 ));
 
-/// Assemble and package the module as self-contained release tarballs.
+/// Assemble, install to a staging directory, then package each provider's
+/// output as a self-contained release tarball in `dist/`.
 ///
 /// ```text
-/// module/build/
-///   claude/...     → forge-core-claude-v0.5.0.tar.gz
-///   gemini/...     → forge-core-gemini-v0.5.0.tar.gz
+/// module/
+///   build/staging/.claude/...   ← install output (with .manifest)
+///   dist/{name}-claude-v{version}.tar.gz
 /// ```
+///
+/// Each tarball wraps `.{provider}/` (with `.manifest` inside, written by
+/// install), a generated `Makefile`, and the module `README.md`.
 pub fn execute(path: &str, embed: bool) -> Result<ActionResult, Error> {
-    let mut result = assemble::execute(path)?;
-
     let module_root = Path::new(path);
-    let build_dir = module_root.join("build");
-
-    if !build_dir.is_dir() {
-        return Ok(result);
-    }
-
-    let manifest = module::load(module_root).map_err(|error| {
+    let module_manifest = module::load(module_root).map_err(|error| {
         Error::new(
             ErrorKind::Config,
             format!("cannot load module.yaml: {error}"),
         )
     })?;
 
+    // Stage everything via install (assemble + deploy + .manifest)
+    let staging_dir = module_root.join("build").join("staging");
+    let _ = fs::remove_dir_all(&staging_dir);
+    let mut result = install::execute(
+        path,
+        Some(&staging_dir.to_string_lossy()),
+        true,
+        false,
+        false,
+    )?;
+    result.installed.clear();
+    result.skipped.clear();
+
     let merged_config = config::load_merged_config(module_root)?;
     let providers = config::load_providers(&merged_config)?;
     let readme_path = module_root.join("README.md");
+    let dist_dir = module_root.join("dist");
+    fs::create_dir_all(&dist_dir).map_err(|error| {
+        Error::new(
+            ErrorKind::Io,
+            format!("cannot create {}: {error}", dist_dir.display()),
+        )
+    })?;
 
-    for provider_name in providers.keys() {
-        let provider_dir = build_dir.join(provider_name);
-        if !provider_dir.is_dir() {
+    for (provider_name, provider_config) in &providers {
+        let staged_provider = staging_dir.join(&provider_config.target);
+        if !staged_provider.is_dir() {
             continue;
         }
 
-        let wrapper_name = format!("{}-{provider_name}-v{}", manifest.name, manifest.version);
-        let wrapper_dir = build_dir.join(&wrapper_name);
-        let dotfolder = wrapper_dir.join(format!(".{provider_name}"));
-
-        // Move assembled content into .{provider}/ inside wrapper
+        let wrapper_name = format!(
+            "{}-{provider_name}-v{}",
+            module_manifest.name, module_manifest.version
+        );
+        let wrapper_dir = module_root.join("build").join(&wrapper_name);
+        let _ = fs::remove_dir_all(&wrapper_dir);
         fs::create_dir_all(&wrapper_dir).map_err(|error| {
             Error::new(
                 ErrorKind::Io,
                 format!("cannot create {}: {error}", wrapper_dir.display()),
             )
         })?;
-        fs::rename(&provider_dir, &dotfolder).map_err(|error| {
+
+        // Move installed provider tree (including .manifest) into wrapper
+        let dotfolder = wrapper_dir.join(&provider_config.target);
+        fs::rename(&staged_provider, &dotfolder).map_err(|error| {
             Error::new(
                 ErrorKind::Io,
                 format!("cannot move {provider_name}: {error}"),
@@ -74,17 +94,24 @@ pub fn execute(path: &str, embed: bool) -> Result<ActionResult, Error> {
             let _ = fs::copy(&readme_path, wrapper_dir.join("README.md"));
         }
 
-        // Tar and clean up
-        let tarball_path = build_dir.join(format!("{wrapper_name}.tar.gz"));
-        create_tarball(&build_dir, &tarball_path, &wrapper_name, provider_name)?;
+        // Tar to dist/ and clean staging
+        let tarball_path = dist_dir.join(format!("{wrapper_name}.tar.gz"));
+        create_tarball(
+            &module_root.join("build"),
+            &tarball_path,
+            &wrapper_name,
+            provider_name,
+        )?;
         let _ = fs::remove_dir_all(&wrapper_dir);
 
         result.installed.push(DeployedFile {
-            source: format!(".{provider_name}"),
+            source: provider_config.target.clone(),
             target: tarball_path.to_string_lossy().to_string(),
             provider: provider_name.clone(),
         });
     }
+
+    let _ = fs::remove_dir_all(&staging_dir);
 
     if embed {
         eprintln!("warning: --embed is not yet implemented");

--- a/templates/make/dist.mk
+++ b/templates/make/dist.mk
@@ -19,5 +19,5 @@ install:
 	 if [ "$$SRC" = "$$DST" ]; then \
 	     echo "Already in $(TARGET)/ — nothing to do"; \
 	 else \
-	     cp -r .${PROVIDER}/* "$(TARGET)/" && echo "Installed to $(TARGET)/"; \
+	     cp -R .${PROVIDER}/. "$(TARGET)/" && echo "Installed to $(TARGET)/"; \
 	 fi


### PR DESCRIPTION
## Summary

Two improvements to \`forge release\` after #24:

- Tarballs now land in \`dist/\` instead of \`build/\`. The \`build/\` directory is wiped on every \`assemble\`, so a subsequent \`forge install\` destroyed previous release tarballs. \`dist/\` is preserved across runs.
- \`forge release\` delegates to \`install::execute()\` against a staging directory, then reshuffles per-provider output into wrapper directories. This produces \`.{provider}/.manifest\` matching what \`forge install\` creates at user targets — round-trip consistent with \`forge provenance\`.
- Install Makefile in tarballs uses \`cp -R .{provider}/.\` instead of \`/*\` so hidden files (\`.manifest\`, \`.provenance/\`) get copied.

Net change: ~120 lines of release/mod.rs (down from ~210 in an earlier draft) — manifest/walk/strip logic delegated to existing install code.

## Test plan

- [x] \`cargo test\` — 393 tests pass
- [x] \`forge release .\` on proton-agents v0.3.0 produces 4 tarballs in \`dist/\`
- [x] Tarball contains \`.{provider}/.manifest\` (186 lines, fingerprints + provenance refs)
- [x] \`make install\` extracts \`.manifest\` and \`.provenance/\` correctly to \`~/.claude/\`
- [x] Tarball structure matches \`forge install\` target output