### PR TITLE
fix: bump SCRIPT_SHA in pre-commit template

### DIFF
--- a/templates/init/.githooks/pre-commit
+++ b/templates/init/.githooks/pre-commit
@@ -5,7 +5,7 @@ set -euo pipefail
 # Canonical source: https://github.com/N4M3Z/forge-cli/blob/main/templates/init/.githooks/pre-commit
 
 SCRIPT_URL="https://raw.githubusercontent.com/N4M3Z/forge-cli/main/scripts/validate.sh"
-SCRIPT_SHA="f1fc47c463097005152ff2dcd5c8e57e7bb55d9b8c7a61c5b697fc662aeb5bde"
+SCRIPT_SHA="62cdb4b53f6eb503db919dd2c0f484ec8b38fc2dd943a4e339a5e59b6a9720fa"
 
 if command -v prek >/dev/null 2>&1; then
     prek run --all-files

--- a/templates/init/CONTRIBUTING.md
+++ b/templates/init/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`.
 
 1. Fork and create a branch
 2. Make changes following the conventions above
-3. `make test`
+3. `make validate`
 4. Open a PR against `main`
 
 CI runs validation on every PR. The `main` branch requires passing CI before merge.


### PR DESCRIPTION
## Summary

Two bugs in `templates/init/` where the generated module files drift against each other. `forge init`-generated modules fail their own pre-commit fallback and have a mismatched Makefile↔CONTRIBUTING.

- **SCRIPT_SHA pin stale**: `templates/init/.githooks/pre-commit` pinned `SCRIPT_SHA=f1fc47c4…` against `main/scripts/validate.sh`, but `main`'s hash moved after commit [`44f2b686`](https://github.com/N4M3Z/forge-cli/commit/44f2b686) (\"feat: adopt prek as validation entry point\"). Current hash is `62cdb4b5…`. Every `forge init`-generated module's pre-commit fallback exits 1 for developers without `prek` or `forge` on PATH. Bumped to the current `main` hash.
- **CONTRIBUTING template `make test` drift**: the init Makefile template exposes `install`, `validate`, `clean`, `help` — no `test` target. The CONTRIBUTING template's PR step 3 still said `make test` from an older Makefile shape. Updated to `make validate`.

Longer-term, consider pinning the `SCRIPT_URL` to a release tag (`v0.3.x`) so the hash stops drifting on every `main` update. Tracked as follow-up.

## Test plan

- [x] `curl -sfL <SCRIPT_URL> | shasum -a 256` matches the new `SCRIPT_SHA`
- [x] Hook file parses as valid bash (`bash -n`)
- [x] Grep confirms `make test` → `make validate` in the template
- [ ] Reviewer: run `forge init /tmp/test-module && cd /tmp/test-module && make validate` without `prek` / `forge` on PATH to confirm the hash-pinned fallback succeeds

## Related PRs

- [forge-dev#2](https://github.com/N4M3Z/forge-dev/pull/2) — downstream consumer picking up the same fix in its compliance baseline