### PR TITLE
fix: positional path means different things per verb — drop it everywhere

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,7 +7,7 @@ set -euo pipefail
 if command -v prek >/dev/null 2>&1; then
     prek run --all-files
 elif command -v forge >/dev/null 2>&1; then
-    forge validate .
+    forge validate
 else
     echo ""
     echo "  ⚠  Neither prek nor forge found — using validate.sh fallback"

--- a/.github/workflows/module-release.yaml
+++ b/.github/workflows/module-release.yaml
@@ -25,7 +25,7 @@ jobs:
               run: make validate
 
             - name: Release
-              run: forge release .
+              run: forge release
 
             - name: Create GitHub release
               env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,6 @@ repos:
 
           - id: forge-validate
             name: forge validate
-            entry: forge validate .
+            entry: forge validate
             language: system
             pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 - id: forge-validate
   name: forge validate
-  entry: forge validate .
+  entry: forge validate
   language: rust
   pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Removed
 
-- `forge install`, `forge deploy`, `forge clean` no longer accept the source path as a positional argument; pass it via `--source <DIR>` instead (defaults to `.`)
+- All commands drop their positional path arguments. Same positional meant different things across verbs (`forge init <PATH>` wrote into PATH, `forge install <PATH>` read from PATH); every command now uses named flags (`--source`, `--target`, `--upstream`).
+    - `install`, `deploy`, `clean`, `assemble`, `validate`, `release`: source is `--source <DIR>`, defaults to `.`
+    - `init`: target is `--target <DIR>`, no default (scaffolding requires explicit destination)
+    - `copy`: both `--source <DIR>` and `--target <DIR>` are required
+    - `provenance`: inspection target is `--target <DIR_OR_FILE>` (defaults to `.`); the existing source-URI filter is renamed from `--source` to `--source-uri` to avoid name collision
+    - `drift`: source defaults to `.` via `--source`; the second positional is now `--upstream <DIR>` (renamed from `target` since semantically it is the upstream reference)
 
 ## [0.3.1] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - `forge copy` writes SLSA provenance sidecars to `.provenance/` in the target tree (opt-out via `--skip-provenance`)
 - `forge drift` consumes copy provenance sidecars to surface source URI on same-name matches and pair files across renames
+- `forge install` and `forge deploy` accept `--provider <NAME>` (repeatable) to deploy only the named provider(s); unknown names error with the available list
+- `forge install`, `forge deploy`, and `forge clean` default the source path to `.` when `--source` is omitted
 
 ### Changed
 
 - `manifest::generate_statement` builds the SLSA statement via typed `serde_yaml::to_string` (eliminates YAML injection risk in interpolated fields)
 - Copy provenance subject names and dependency URIs use POSIX path separators regardless of host OS
+- `forge install`, `forge deploy`, `forge clean` refuse to operate on a directory without `module.yaml`; the error names the missing file and the corrective `--source` invocation
+- The YAML deep-merge "type conflict" warning now identifies the conflicting key path and the involved YAML types
+- `forge install --help` lists the available providers, explains the `--target` per-provider join, and shows two example invocations
+
+### Removed
+
+- `forge install`, `forge deploy`, `forge clean` no longer accept the source path as a positional argument; pass it via `--source <DIR>` instead (defaults to `.`)
 
 ## [0.3.1] - 2026-04-16
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -35,11 +35,11 @@ The project uses a `Makefile` to orchestrate common development tasks.
 - **Clean:** `make clean` (removes build artifacts)
 
 ### CLI Usage Examples
-- **Full Install:** `forge install <module_path>`
-- **Assemble Only:** `forge assemble <module_path>`
-- **Deploy Only:** `forge deploy <module_path>`
-- **Validate Module:** `forge validate <module_path>`
-- **Check for Drift:** `forge drift <local_path> <upstream_path>`
+- **Full Install:** `forge install [--source <module_path>]` (defaults to `.`)
+- **Assemble Only:** `forge assemble [--source <module_path>]`
+- **Deploy Only:** `forge deploy [--source <module_path>]`
+- **Validate Module:** `forge validate [--source <module_path>]`
+- **Check for Drift:** `forge drift [--source <local_path>] --upstream <upstream_path>`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -112,82 +112,102 @@ providers:
 
 ## Usage
 
-Assemble and deploy a module to all provider directories:
+Every command takes its inputs as named flags. Source modules use `--source <DIR>` (defaults to `.` for in-tree commands), targets use `--target <DIR>`, upstreams use `--upstream <DIR>`. There are no positional path arguments.
+
+Assemble and deploy the current module to all provider directories:
 
 ```sh
-forge install path/to/module
+forge install
 ```
 
-Deploy to a specific directory:
+Deploy under a specific base directory (claude → `<DIR>/.claude`, opencode → `<DIR>/.opencode`, etc.):
 
 ```sh
-forge install path/to/module --target ~/project
+forge install --target ~/project
+```
+
+Deploy only one provider:
+
+```sh
+forge install --target ~/project --provider opencode
+```
+
+Install from a different module:
+
+```sh
+forge install --source path/to/module --target ~/project
 ```
 
 Overwrite user-modified files:
 
 ```sh
-forge install path/to/module --force
+forge install --force
 ```
 
 Remove stale files from previous installs:
 
 ```sh
-forge clean path/to/module
+forge clean
 ```
 
 Build only, no deployment:
 
 ```sh
-forge assemble path/to/module
+forge assemble
 ```
 
 Deploy from an existing build/ directory:
 
 ```sh
-forge deploy path/to/module
+forge deploy
 ```
 
 Validate module structure, schemas, linters, and tests:
 
 ```sh
-forge validate path/to/module
+forge validate
 ```
 
 Compare a module against an upstream reference:
 
 ```sh
-forge drift . ../forge-core
+forge drift --upstream ../forge-core
 ```
 
 Suppress expected per-project frontmatter keys:
 
 ```sh
-forge drift . ../forge-core --ignore project,author
+forge drift --upstream ../forge-core --ignore project,author
 ```
 
 Show provenance chain for a deployed file:
 
 ```sh
-forge provenance ~/.claude/rules/UseRTK.md
+forge provenance --target ~/.claude/rules/UseRTK.md
 ```
 
 Scan a directory for files without provenance:
 
 ```sh
-forge provenance ~/.claude --show-orphans
+forge provenance --target ~/.claude --show-orphans
 ```
 
 Copy source files directly without assembly:
 
 ```sh
-forge copy path/to/module --target ~/project
+forge copy --source path/to/module --target ~/project
 ```
 
 Package assembled content as tarballs:
 
 ```sh
-forge release path/to/module
+forge release
+```
+
+Scaffold a new module:
+
+```sh
+forge init --target path/to/new-module
 ```
 
 All commands support `--json` for machine-readable output.

--- a/src/cli/assemble/mod.rs
+++ b/src/cli/assemble/mod.rs
@@ -42,6 +42,19 @@ pub fn execute(path: &str) -> Result<ActionResult, Error> {
             format!("module directory not found: {}", module_root.display()),
         ));
     }
+    let module_manifest = module_root.join("module.yaml");
+    if !module_manifest.is_file() {
+        return Err(Error::new(
+            commands::error::ErrorKind::Config,
+            format!(
+                "no module.yaml found at {} \
+                 \n\nThe --source argument must point to a forge module root. \
+                 \nRun `forge init {}` to scaffold one, or pass --source <module-path>.",
+                module_manifest.display(),
+                module_root.display(),
+            ),
+        ));
+    }
     let mut result = ActionResult::new();
 
     let merged_config = config::load_merged_config(module_root)?;

--- a/src/cli/deploy/mod.rs
+++ b/src/cli/deploy/mod.rs
@@ -21,15 +21,22 @@ use crate::cli::config;
 pub fn execute(
     path: &str,
     target: Option<&str>,
+    requested_providers: &[String],
     force: bool,
     prune: bool,
     _interactive: bool,
 ) -> Result<ActionResult, Error> {
     let module_root = Path::new(path);
+    require_module_root(module_root)?;
     let mut result = ActionResult::new();
 
     let merged_config = config::load_merged_config(module_root)?;
-    let providers = config::load_providers(&merged_config)?;
+    let mut providers = config::load_providers(&merged_config)?;
+
+    if !requested_providers.is_empty() {
+        providers = filter_requested_providers(&providers, requested_providers)?;
+    }
+
     let module_source_uri = config::load_source_uri(module_root);
     let module_name = if module_source_uri.is_empty() {
         None
@@ -209,6 +216,74 @@ fn deploy_provider_files(
                 }
             }
         }
+    }
+    Ok(())
+}
+
+/// Keep only the provider entries the user requested. Each requested name is
+/// matched against provider keys, target directories, and aliases (the same
+/// rules `ProviderConfig::matches_target` uses elsewhere). Unknown names
+/// produce a single error listing all available choices.
+fn filter_requested_providers(
+    providers: &HashMap<String, commands::provider::ProviderConfig>,
+    requested: &[String],
+) -> Result<HashMap<String, commands::provider::ProviderConfig>, Error> {
+    let mut matched: HashMap<String, commands::provider::ProviderConfig> = HashMap::new();
+    let mut unknown: Vec<String> = Vec::new();
+
+    for requested_name in requested {
+        let hit = providers
+            .iter()
+            .find(|(key, config)| config.matches_target(requested_name, key));
+
+        match hit {
+            Some((key, config)) => {
+                matched.entry(key.clone()).or_insert_with(|| config.clone());
+            }
+            None => unknown.push(requested_name.clone()),
+        }
+    }
+
+    if !unknown.is_empty() {
+        let mut available: Vec<&String> = providers.keys().collect();
+        available.sort();
+        return Err(Error::new(
+            ErrorKind::Config,
+            format!(
+                "unknown provider(s): {}. Available: {}",
+                unknown.join(", "),
+                available
+                    .into_iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        ));
+    }
+
+    Ok(matched)
+}
+
+/// Refuse to operate on a path that isn't a forge module root.
+fn require_module_root(module_root: &Path) -> Result<(), Error> {
+    if !module_root.is_dir() {
+        return Err(Error::new(
+            ErrorKind::Io,
+            format!("source directory not found: {}", module_root.display()),
+        ));
+    }
+    let manifest_path = module_root.join("module.yaml");
+    if !manifest_path.is_file() {
+        return Err(Error::new(
+            ErrorKind::Config,
+            format!(
+                "no module.yaml found at {} \
+                 \n\nThe --source argument must point to a forge module root. \
+                 \nRun `forge init {}` to scaffold one, or pass --source <module-path>.",
+                manifest_path.display(),
+                module_root.display(),
+            ),
+        ));
     }
     Ok(())
 }

--- a/src/cli/install/mod.rs
+++ b/src/cli/install/mod.rs
@@ -15,12 +15,13 @@ use super::deploy;
 pub fn execute(
     path: &str,
     target: Option<&str>,
+    requested_providers: &[String],
     force: bool,
     prune: bool,
     interactive: bool,
 ) -> Result<ActionResult, Error> {
     assemble::execute(path)?;
-    deploy::execute(path, target, force, prune, interactive)
+    deploy::execute(path, target, requested_providers, force, prune, interactive)
 }
 
 #[cfg(test)]

--- a/src/cli/install/tests.rs
+++ b/src/cli/install/tests.rs
@@ -1,10 +1,41 @@
 use super::*;
 use tempfile::TempDir;
 
+fn write_module_yaml(directory: &std::path::Path) {
+    std::fs::write(
+        directory.join("module.yaml"),
+        "name: test\nversion: 0.1.0\ndescription: test\nevents: []\n",
+    )
+    .unwrap();
+}
+
 #[test]
 fn execute_errors_on_missing_module() {
-    let result = execute("/nonexistent/module", None, false, false, false);
+    let result = execute("/nonexistent/module", None, &[], false, false, false);
     assert!(result.is_err());
+}
+
+#[test]
+fn execute_errors_on_directory_without_module_yaml() {
+    let directory_without_module = TempDir::new().unwrap();
+    let result = execute(
+        &directory_without_module.path().to_string_lossy(),
+        None,
+        &[],
+        false,
+        false,
+        false,
+    );
+    let error = result.expect_err("expected install to refuse non-module directory");
+    let message = error.to_string();
+    assert!(
+        message.contains("module.yaml"),
+        "error message should mention the missing module.yaml: {message}"
+    );
+    assert!(
+        message.contains("--source"),
+        "error message should mention the --source argument: {message}"
+    );
 }
 
 #[test]
@@ -15,19 +46,88 @@ fn execute_succeeds_on_empty_module() {
         "providers:\n    claude:\n        target: .claude\n",
     )
     .unwrap();
-    std::fs::write(
-        temp_directory.path().join("module.yaml"),
-        "name: test\nversion: 0.1.0\ndescription: test\nevents: []\n",
-    )
-    .unwrap();
+    write_module_yaml(temp_directory.path());
 
     let target = TempDir::new().unwrap();
     let result = execute(
         &temp_directory.path().to_string_lossy(),
         Some(&target.path().to_string_lossy()),
+        &[],
         false,
         false,
         false,
     );
     assert!(result.is_ok());
+}
+
+#[test]
+fn execute_unknown_provider_lists_available_choices() {
+    let module_directory = TempDir::new().unwrap();
+    write_module_yaml(module_directory.path());
+
+    let target = TempDir::new().unwrap();
+    let result = execute(
+        &module_directory.path().to_string_lossy(),
+        Some(&target.path().to_string_lossy()),
+        &["definitely-not-a-provider".to_string()],
+        false,
+        false,
+        false,
+    );
+    let error = result.expect_err("unknown provider must error");
+    let message = error.to_string();
+    assert!(
+        message.contains("definitely-not-a-provider"),
+        "error should echo the bad provider name: {message}"
+    );
+    assert!(
+        message.contains("Available:"),
+        "error should list available providers: {message}"
+    );
+    assert!(
+        message.contains("claude"),
+        "available list should include claude: {message}"
+    );
+}
+
+#[test]
+fn execute_provider_filter_skips_unrequested_providers() {
+    let module_directory = TempDir::new().unwrap();
+    write_module_yaml(module_directory.path());
+    let rules_directory = module_directory.path().join("rules");
+    std::fs::create_dir_all(&rules_directory).unwrap();
+    std::fs::write(rules_directory.join("OnlyRule.md"), "body\n").unwrap();
+
+    let target = TempDir::new().unwrap();
+    let result = execute(
+        &module_directory.path().to_string_lossy(),
+        Some(&target.path().to_string_lossy()),
+        &["opencode".to_string()],
+        false,
+        false,
+        false,
+    )
+    .expect("install should succeed for known provider");
+
+    let opencode_rule = target.path().join(".opencode/rules/OnlyRule.md");
+    assert!(
+        opencode_rule.exists(),
+        "opencode rule should be deployed at {}",
+        opencode_rule.display()
+    );
+
+    for skipped in [".claude", ".gemini", ".codex"] {
+        let path = target.path().join(skipped).join("rules/OnlyRule.md");
+        assert!(
+            !path.exists(),
+            "{skipped} should be skipped when --provider opencode given"
+        );
+    }
+    assert!(
+        result
+            .installed
+            .iter()
+            .all(|file| file.provider == "opencode"),
+        "every deployed file should belong to opencode"
+    );
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,8 +27,9 @@ struct Cli {
 enum Command {
     /// Initialize a new forge module with required files and schemas
     Init {
-        /// Path to the module root (created if missing)
-        path: String,
+        /// Directory to scaffold the new module into (created if missing).
+        #[arg(long, value_name = "DIR")]
+        target: String,
     },
 
     /// Assemble and deploy module content to provider directories
@@ -71,8 +72,9 @@ enum Command {
 
     /// Assemble module content into build/
     Assemble {
-        /// Path to the module root
-        path: String,
+        /// Module root to assemble (must contain module.yaml). Defaults to `.`.
+        #[arg(long, value_name = "DIR", default_value = ".")]
+        source: String,
     },
 
     /// Deploy assembled files from build/ to provider directories
@@ -102,11 +104,12 @@ enum Command {
 
     /// Copy source files directly to a target directory (no assembly, no transforms)
     Copy {
-        /// Path to the module root
-        path: String,
+        /// Module root to copy from.
+        #[arg(long, value_name = "DIR")]
+        source: String,
 
-        /// Target directory to copy into
-        #[arg(long)]
+        /// Directory to copy into.
+        #[arg(long, value_name = "DIR")]
         target: String,
 
         /// Skip SLSA provenance sidecar generation
@@ -116,18 +119,20 @@ enum Command {
 
     /// Validate module files against schemas
     Validate {
-        /// Path to the module root
-        path: String,
+        /// Module root to validate (must contain module.yaml). Defaults to `.`.
+        #[arg(long, value_name = "DIR", default_value = ".")]
+        source: String,
     },
 
     /// Show provenance information for a deployed file or directory
     Provenance {
-        /// Path to a deployed file or provider directory
-        path: String,
+        /// Deployed file or provider directory to inspect. Defaults to `.`.
+        #[arg(long, value_name = "DIR_OR_FILE", default_value = ".")]
+        target: String,
 
-        /// Filter by source module URI
-        #[arg(long)]
-        source: Option<String>,
+        /// Filter by source module URI (e.g. <https://github.com/...>)
+        #[arg(long, value_name = "URI")]
+        source_uri: Option<String>,
 
         /// Show files without provenance
         #[arg(long)]
@@ -136,11 +141,13 @@ enum Command {
 
     /// Compare module content against an upstream reference
     Drift {
-        /// Path to the module root (source)
+        /// Module root to compare. Defaults to `.`.
+        #[arg(long, value_name = "DIR", default_value = ".")]
         source: String,
 
-        /// Path to the upstream reference module
-        target: Option<String>,
+        /// Upstream reference module to compare against.
+        #[arg(long, value_name = "DIR")]
+        upstream: String,
 
         /// Comma-separated keys to ignore (use "body" to ignore body drift)
         #[arg(long, value_delimiter = ',')]
@@ -161,8 +168,9 @@ enum Command {
 
     /// Assemble and package module as release tarballs
     Release {
-        /// Path to the module root
-        path: String,
+        /// Module root to package (must contain module.yaml). Defaults to `.`.
+        #[arg(long, value_name = "DIR", default_value = ".")]
+        source: String,
 
         /// Embed assets into the binary
         #[arg(long)]
@@ -177,7 +185,7 @@ pub fn run() -> i32 {
     let args = Cli::parse();
 
     let (result, verb) = match args.command {
-        Command::Init { path } => (init::execute(&path), "initialized"),
+        Command::Init { target } => (init::execute(&target), "initialized"),
         Command::Install {
             source,
             target,
@@ -195,7 +203,7 @@ pub fn run() -> i32 {
             ),
             "deployed",
         ),
-        Command::Assemble { path } => (assemble::execute(&path), "assembled"),
+        Command::Assemble { source } => (assemble::execute(&source), "assembled"),
         Command::Deploy {
             source,
             target,
@@ -214,17 +222,22 @@ pub fn run() -> i32 {
             "deployed",
         ),
         Command::Copy {
-            path,
+            source,
             target,
             skip_provenance,
-        } => (copy::execute(&path, &target, skip_provenance), "copied"),
-        Command::Validate { path } => (validate::execute(&path), "validated"),
+        } => (copy::execute(&source, &target, skip_provenance), "copied"),
+        Command::Validate { source } => (validate::execute(&source), "validated"),
         Command::Provenance {
-            path,
-            source,
+            target,
+            source_uri,
             show_orphans,
         } => {
-            return match provenance::execute(&path, source.as_deref(), show_orphans, args.json) {
+            return match provenance::execute(
+                &target,
+                source_uri.as_deref(),
+                show_orphans,
+                args.json,
+            ) {
                 Ok(code) => code,
                 Err(error) => {
                     eprintln!("fatal: {error}");
@@ -234,11 +247,10 @@ pub fn run() -> i32 {
         }
         Command::Drift {
             source,
-            target,
+            upstream,
             ignore,
         } => {
-            let upstream = target.as_deref().unwrap_or(".");
-            return match drift::execute(&source, upstream, &ignore, args.json) {
+            return match drift::execute(&source, &upstream, &ignore, args.json) {
                 Ok(code) => code,
                 Err(error) => {
                     eprintln!("fatal: {error}");
@@ -250,7 +262,7 @@ pub fn run() -> i32 {
             deploy::execute(&source, target.as_deref(), &[], false, true, false),
             "cleaned",
         ),
-        Command::Release { path, embed } => (release::execute(&path, embed), "released"),
+        Command::Release { source, embed } => (release::execute(&source, embed), "released"),
     };
 
     match result {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,13 +32,33 @@ enum Command {
     },
 
     /// Assemble and deploy module content to provider directories
+    #[command(after_help = "EXAMPLES:\n  \
+        # Install the current directory's module for all providers under ~/\n  \
+        cd ~/Modules/forge-core && forge install --target ~\n  \
+        \n  \
+        # Install a specific module for opencode only\n  \
+        forge install --source ~/Modules/forge-core --target ~ --provider opencode\n\n\
+        TARGET LAYOUT:\n  \
+        --target <DIR> deploys each provider to <DIR>/<provider-target>:\n    \
+        claude   → <DIR>/.claude\n    \
+        codex    → <DIR>/.codex\n    \
+        gemini   → <DIR>/.gemini\n    \
+        opencode → <DIR>/.opencode\n  \
+        Without --target, providers deploy to those paths under the current directory.")]
     Install {
-        /// Path to the module root
-        path: String,
+        /// Module root to install from (must contain module.yaml). Defaults to `.`.
+        #[arg(long, value_name = "DIR", default_value = ".")]
+        source: String,
 
-        /// Deploy to a specific directory instead of default scope
-        #[arg(long)]
+        /// Base directory under which each provider gets its own subdirectory.
+        /// Without this flag, providers deploy under the current directory.
+        #[arg(long, value_name = "DIR")]
         target: Option<String>,
+
+        /// Deploy only the named provider(s). Repeatable.
+        /// Available: claude, codex, gemini, opencode.
+        #[arg(long, value_name = "NAME")]
+        provider: Vec<String>,
 
         /// Overwrite user-modified files
         #[arg(long)]
@@ -57,12 +77,19 @@ enum Command {
 
     /// Deploy assembled files from build/ to provider directories
     Deploy {
-        /// Path to the module root
-        path: String,
+        /// Module root containing build/ to deploy from. Defaults to `.`.
+        #[arg(long, value_name = "DIR", default_value = ".")]
+        source: String,
 
-        /// Deploy to a specific directory instead of default scope
-        #[arg(long)]
+        /// Base directory under which each provider gets its own subdirectory.
+        /// Without this flag, providers deploy under the current directory.
+        #[arg(long, value_name = "DIR")]
         target: Option<String>,
+
+        /// Deploy only the named provider(s). Repeatable.
+        /// Available: claude, codex, gemini, opencode.
+        #[arg(long, value_name = "NAME")]
+        provider: Vec<String>,
 
         /// Overwrite user-modified files
         #[arg(long)]
@@ -122,11 +149,13 @@ enum Command {
 
     /// Remove stale files from previous installs
     Clean {
-        /// Path to the module root
-        path: String,
+        /// Module root whose manifests drive the cleanup. Defaults to `.`.
+        #[arg(long, value_name = "DIR", default_value = ".")]
+        source: String,
 
-        /// Clean a specific directory instead of default scope
-        #[arg(long)]
+        /// Base directory under which each provider's files were deployed.
+        /// Without this flag, the current directory is used.
+        #[arg(long, value_name = "DIR")]
         target: Option<String>,
     },
 
@@ -150,22 +179,38 @@ pub fn run() -> i32 {
     let (result, verb) = match args.command {
         Command::Init { path } => (init::execute(&path), "initialized"),
         Command::Install {
-            path,
+            source,
             target,
+            provider,
             force,
             interactive,
         } => (
-            install::execute(&path, target.as_deref(), force, false, interactive),
+            install::execute(
+                &source,
+                target.as_deref(),
+                &provider,
+                force,
+                false,
+                interactive,
+            ),
             "deployed",
         ),
         Command::Assemble { path } => (assemble::execute(&path), "assembled"),
         Command::Deploy {
-            path,
+            source,
             target,
+            provider,
             force,
             interactive,
         } => (
-            deploy::execute(&path, target.as_deref(), force, false, interactive),
+            deploy::execute(
+                &source,
+                target.as_deref(),
+                &provider,
+                force,
+                false,
+                interactive,
+            ),
             "deployed",
         ),
         Command::Copy {
@@ -201,8 +246,8 @@ pub fn run() -> i32 {
                 }
             };
         }
-        Command::Clean { path, target } => (
-            deploy::execute(&path, target.as_deref(), false, true, false),
+        Command::Clean { source, target } => (
+            deploy::execute(&source, target.as_deref(), &[], false, true, false),
             "cleaned",
         ),
         Command::Release { path, embed } => (release::execute(&path, embed), "released"),

--- a/src/cli/release/mod.rs
+++ b/src/cli/release/mod.rs
@@ -39,6 +39,7 @@ pub fn execute(path: &str, embed: bool) -> Result<ActionResult, Error> {
     let mut result = install::execute(
         path,
         Some(&staging_dir.to_string_lossy()),
+        &[],
         true,
         false,
         false,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -52,7 +52,7 @@ impl AssemblyRule {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ProviderConfig {
     pub target: String,
     pub assembly: Option<Vec<String>>,

--- a/src/yaml/merge.rs
+++ b/src/yaml/merge.rs
@@ -37,7 +37,7 @@ pub fn deep_merge(defaults_content: &str, override_content: &str) -> Result<Stri
     let overlay: Value = serde_yaml::from_str(override_content)
         .map_err(|e| format!("failed to parse override YAML: {e}"))?;
 
-    merge_value(&mut base, overlay);
+    merge_value(&mut base, overlay, "");
 
     serde_yaml::to_string(&base).map_err(|e| format!("failed to serialize merged YAML: {e}"))
 }
@@ -47,23 +47,55 @@ pub fn deep_merge(defaults_content: &str, override_content: &str) -> Result<Stri
 /// Type conflicts (e.g. base is a mapping, overlay is a sequence) keep the base
 /// value and skip the overlay. This prevents downstream deserialization failures
 /// when a module's config uses a different YAML type than the embedded defaults.
-fn merge_value(base: &mut Value, overlay: Value) {
+fn merge_value(base: &mut Value, overlay: Value, key_path: &str) {
     match (&mut *base, overlay) {
         (Value::Mapping(base_map), Value::Mapping(overlay_map)) => {
             for (key, overlay_val) in overlay_map {
+                let key_label = key.as_str().map_or_else(|| "?".to_string(), str::to_string);
+                let nested_path = if key_path.is_empty() {
+                    key_label
+                } else {
+                    format!("{key_path}.{key_label}")
+                };
                 match base_map.get_mut(&key) {
-                    Some(base_val) => merge_value(base_val, overlay_val),
+                    Some(base_val) => merge_value(base_val, overlay_val, &nested_path),
                     None => {
                         base_map.insert(key, overlay_val);
                     }
                 }
             }
         }
-        (Value::Mapping(_), _) | (_, Value::Mapping(_)) => {
-            eprintln!("warning: config type conflict (mapping vs non-mapping), keeping default");
+        (Value::Mapping(_), overlay_value) => {
+            warn_type_conflict(key_path, "mapping", describe_value(&overlay_value));
         }
-        (base, overlay) => {
-            *base = overlay;
+        (base_value, Value::Mapping(_)) => {
+            warn_type_conflict(key_path, describe_value(base_value), "mapping");
         }
+        (base_value, overlay) => {
+            *base_value = overlay;
+        }
+    }
+}
+
+fn warn_type_conflict(key_path: &str, base_type: &str, overlay_type: &str) {
+    let location = if key_path.is_empty() {
+        "<root>".to_string()
+    } else {
+        key_path.to_string()
+    };
+    eprintln!(
+        "warning: config key `{location}` has incompatible types (defaults: {base_type}, override: {overlay_type}); keeping default"
+    );
+}
+
+fn describe_value(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Sequence(_) => "sequence",
+        Value::Mapping(_) => "mapping",
+        Value::Tagged(_) => "tagged",
     }
 }

--- a/templates/init/.githooks/pre-commit
+++ b/templates/init/.githooks/pre-commit
@@ -10,7 +10,7 @@ SCRIPT_SHA="62cdb4b53f6eb503db919dd2c0f484ec8b38fc2dd943a4e339a5e59b6a9720fa"
 if command -v prek >/dev/null 2>&1; then
     prek run --all-files
 elif command -v forge >/dev/null 2>&1; then
-    forge validate .
+    forge validate
 else
     echo ""
     echo "  ⚠  Neither prek nor forge found — using validate.sh fallback"

--- a/templates/init/.pre-commit-config.yaml
+++ b/templates/init/.pre-commit-config.yaml
@@ -37,6 +37,6 @@ repos:
 
           - id: forge-validate
             name: forge validate
-            entry: forge validate .
+            entry: forge validate
             language: system
             pass_filenames: false

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -90,6 +90,7 @@ fn install_deploys_agent_to_all_providers() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -134,6 +135,7 @@ fn install_maps_model_tier_for_claude() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -163,6 +165,7 @@ fn install_strips_rule_frontmatter_for_claude() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -188,6 +191,7 @@ fn install_keeps_links_for_claude_strips_for_gemini() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -215,6 +219,7 @@ fn install_deploys_nested_rules() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -241,6 +246,7 @@ fn install_deploys_skill_with_companion() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -276,6 +282,7 @@ fn install_creates_nested_manifest() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -305,6 +312,7 @@ fn install_deploys_provenance_sidecars() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -335,6 +343,7 @@ fn install_deploys_nested_provenance() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -364,6 +373,7 @@ fn install_is_idempotent() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -376,6 +386,7 @@ fn install_is_idempotent() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -397,6 +408,7 @@ fn install_empty_module_succeeds() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -497,6 +509,7 @@ fn install_respects_targets_frontmatter() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -552,6 +565,7 @@ fn install_targets_multiple_providers() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -597,6 +611,7 @@ fn install_target_writes_manifest_with_correct_fingerprints() {
     forge()
         .args([
             "install",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -436,7 +436,11 @@ fn validate_reports_missing_required_files() {
     .unwrap();
 
     forge()
-        .args(["validate", module_directory.path().to_str().unwrap()])
+        .args([
+            "validate",
+            "--source",
+            module_directory.path().to_str().unwrap(),
+        ])
         .assert()
         .failure()
         .stdout(predicates::str::contains("MISSING README.md"))
@@ -452,7 +456,11 @@ fn validate_passes_complete_module() {
     fs::write(module_directory.path().join("LICENSE"), "EUPL-1.2\n").unwrap();
 
     forge()
-        .args(["validate", module_directory.path().to_str().unwrap()])
+        .args([
+            "validate",
+            "--source",
+            module_directory.path().to_str().unwrap(),
+        ])
         .assert()
         .success();
 }
@@ -470,6 +478,7 @@ fn copy_preserves_frontmatter() {
     forge()
         .args([
             "copy",
+            "--source",
             module_directory.path().to_str().unwrap(),
             "--target",
             target_directory.path().to_str().unwrap(),
@@ -659,7 +668,11 @@ fn validate_catches_mdschema_violation() {
     .unwrap();
 
     forge()
-        .args(["validate", module_directory.path().to_str().unwrap()])
+        .args([
+            "validate",
+            "--source",
+            module_directory.path().to_str().unwrap(),
+        ])
         .assert()
         .failure();
 }

--- a/tests/drift.rs
+++ b/tests/drift.rs
@@ -44,7 +44,9 @@ fn drift_identical_rules_reports_zero_exit() {
     forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
         ])
         .assert()
@@ -64,7 +66,9 @@ fn drift_identical_files_shown_in_json() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -102,7 +106,9 @@ fn drift_body_difference_detected() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -151,7 +157,9 @@ fn drift_frontmatter_difference_detected() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -206,7 +214,9 @@ fn drift_both_frontmatter_and_body_difference() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -239,7 +249,9 @@ fn drift_local_only_file_detected() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -277,7 +289,9 @@ fn drift_upstream_only_file_detected() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -316,7 +330,9 @@ fn drift_skill_body_difference() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -357,7 +373,9 @@ fn drift_agent_model_difference_is_frontmatter() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -394,7 +412,9 @@ fn drift_decisions_compared() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -433,7 +453,9 @@ fn drift_files_without_frontmatter_compared_as_full_body() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -470,7 +492,9 @@ fn drift_nested_rules_compared() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -504,7 +528,9 @@ fn drift_empty_module_against_populated_upstream() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -566,7 +592,9 @@ fn drift_reports_all_content_kinds() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--json",
         ])
@@ -611,7 +639,9 @@ fn ignore_frontmatter_keys_marks_expected() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--ignore",
             "project,author",
@@ -650,7 +680,9 @@ fn ignore_body_marks_expected() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--ignore",
             "body",
@@ -687,7 +719,9 @@ fn ignore_partial_keys_keeps_drift() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--ignore",
             "project",
@@ -722,7 +756,9 @@ fn ignore_both_frontmatter_and_body() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--ignore",
             "project,body",
@@ -757,7 +793,9 @@ fn ignore_body_on_both_drift_keeps_frontmatter() {
     let output = forge()
         .args([
             "drift",
+            "--source",
             module_directory.path().to_str().unwrap(),
+            "--upstream",
             upstream_directory.path().to_str().unwrap(),
             "--ignore",
             "body",


### PR DESCRIPTION
## The problem

`forge` had a single anonymous positional path on every command, but the slot meant opposite things depending on the verb:

| Command | What `forge <verb> .` actually meant |
| --- | --- |
| `forge init .` | Write template files INTO `.` |
| `forge install .` | Read FROM `.` as the module source |
| `forge validate .` | Validate THE module at `.` |
| `forge provenance .` | Inspect the deployment AT `.` |
| `forge drift . ../up` | Compare cwd against `../up` |
| `forge copy ./mod --target ./out` | Read FROM `./mod`, write to `./out` |

You could not look at `forge <verb> .` and know which way the data was flowing. The fallout: `forge install ~` was reasonable to type and exited 0 with two cryptic warnings while installing nothing — `~` got read as a module source, found no `module.yaml`, and the tool went silent. Same for `forge install ~/.opencode`.

## The fix

Drop positional paths from every command. Every input is a named flag whose name says which side of the operation it is on:

- `--source <DIR>` for "read from"
- `--target <DIR>` for "write to" or "inspect at"
- `--upstream <DIR>` for "compare against"

Per command:

| Command | Old | New |
| --- | --- | --- |
| `install`, `deploy`, `clean` | `<PATH>` | `--source <DIR>` (default `.`) |
| `assemble`, `validate`, `release` | `<PATH>` | `--source <DIR>` (default `.`) |
| `init` | `<PATH>` | `--target <DIR>` (REQUIRED — explicit destination for new files) |
| `copy` | `<PATH> --target <DIR>` | `--source <DIR> --target <DIR>` (both REQUIRED) |
| `provenance` | `<PATH> [--source <URI>]` | `--target <DIR_OR_FILE>` (default `.`); URI filter renamed to `--source-uri` |
| `drift` | `<SOURCE> <TARGET>` | `--source <DIR>` (default `.`), `--upstream <DIR>` |

`provenance --source` (a string filter for source-module URI) was renamed to `--source-uri` so the path slot could use the `--source`/`--target` convention consistently.

## Bundled fixes from the same diagnostic session

The silent-success on `forge install ~` had two contributing factors beyond the positional ambiguity:

- **No way to deploy a single provider.** Added `--provider <NAME>` (repeatable) to `install` and `deploy`. Names match the provider key, target dir, or alias from `defaults.yaml`. Unknown names error with the available list.
- **Cryptic config-merge warning.** `warning: config type conflict (mapping vs non-mapping), keeping default` gave no way to find the bad key. Now: `warning: config key 'providers.claude.target' has incompatible types (defaults: mapping, override: string); keeping default`.
- **Silent exit when source isn't a forge module.** `install`, `deploy`, `clean` now refuse on directories without `module.yaml` — the error names the missing file and the corrective `--source` invocation.
- **`install --help` rewrite.** Lists available providers, explains the per-provider `--target` join, shows two example invocations.

## Migration

| Old | New |
| --- | --- |
| `forge install ./mod` | `forge install --source ./mod` |
| `forge install ./mod --target ~/proj` | `forge install --source ./mod --target ~/proj` |
| `forge init ./new-mod` | `forge init --target ./new-mod` |
| `forge drift . ../upstream` | `forge drift --upstream ../upstream` |
| `forge provenance ~/.claude` | `forge provenance --target ~/.claude` |
| `forge copy ./mod --target ./out` | `forge copy --source ./mod --target ./out` |

No deprecation period. Pre-1.0.

## Test plan

- [x] `cargo test` — 405 passed (4 new install tests for the provider filter and module.yaml guard)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `make validate` clean
- [x] Smoke: `forge install --source ~/Modules/forge-core --target /tmp/x --provider opencode` deploys only `.opencode/...`
- [x] Smoke: `forge install --source ~/Modules/forge-core --target /tmp/x --provider nope` errors with the available list
- [x] Smoke: `forge install --source ~` errors with `no module.yaml found at /Users/N4M3Z/module.yaml`
- [x] Repo-internal scripts updated: `.githooks/`, `templates/init/`, both `.pre-commit-config.yaml` files, `.pre-commit-hooks.yaml`, `.github/workflows/module-release.yaml`, `README.md`, `GEMINI.md`
- [x] ADR docs left untouched as historical snapshots

## Open issues considered

Reviewed #18, #28, #29, #30, #31, #33 — none touch the CLI argument surface.