### PR TITLE
fix: forge init deploys hidden template files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `forge init` now deploys all hidden template files (`.pre-commit-config.yaml`, `.gitattributes`, `.gitleaks.toml`, `.gitlab-ci.yml`). The previous near-total dotfile allowlist silently dropped them; replaced with an OS-junk blocklist (`.DS_Store`, `Thumbs.db`, `Desktop.ini`, `._*` resource forks). (#28)
+
 ### Added
 
 - `forge copy` writes SLSA provenance sidecars to `.provenance/` in the target tree (opt-out via `--skip-provenance`)

--- a/src/cli/init/mod.rs
+++ b/src/cli/init/mod.rs
@@ -17,11 +17,7 @@ pub fn execute(path: &str) -> Result<ActionResult, Error> {
         .map_err(|error| Error::new(ErrorKind::Io, format!("cannot create {path}: {error}")))?;
 
     for filename in InitTemplates::iter() {
-        // Skip hidden files like .DS_Store that might be in the templates directory
-        if filename.starts_with('.')
-            && !filename.starts_with(".githooks")
-            && !filename.starts_with(".github")
-        {
+        if is_os_junk(&filename) {
             continue;
         }
         let Some(data) = InitTemplates::get(&filename) else {
@@ -112,6 +108,19 @@ pub fn execute(path: &str) -> Result<ActionResult, Error> {
     }
 
     Ok(result)
+}
+
+/// Drop OS-junk files that find their way into the templates directory but
+/// should not land in scaffolded modules. Everything else (including dotfiles
+/// like `.pre-commit-config.yaml`, `.gitattributes`, `.gitleaks.toml`) is
+/// deployed.
+fn is_os_junk(filename: &str) -> bool {
+    const SKIP: &[&str] = &[".DS_Store", "Thumbs.db", "Desktop.ini"];
+    let basename = std::path::Path::new(filename)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(filename);
+    SKIP.contains(&basename) || basename.starts_with("._")
 }
 
 fn resolve_module_name(module_root: &Path) -> String {

--- a/src/cli/init/tests.rs
+++ b/src/cli/init/tests.rs
@@ -86,6 +86,45 @@ fn init_excludes_customized_files_from_manifest() {
 }
 
 #[test]
+fn init_deploys_hidden_template_files() {
+    let temp_directory = TempDir::new().unwrap();
+    execute(&temp_directory.path().to_string_lossy()).unwrap();
+
+    for required in [
+        ".pre-commit-config.yaml",
+        ".gitattributes",
+        ".gitleaks.toml",
+        ".gitlab-ci.yml",
+    ] {
+        let path = temp_directory.path().join(required);
+        assert!(
+            path.is_file(),
+            "expected hidden template file to be deployed: {required}"
+        );
+    }
+}
+
+#[test]
+fn is_os_junk_blocks_macos_and_windows_artifacts() {
+    assert!(is_os_junk(".DS_Store"));
+    assert!(is_os_junk("subdir/.DS_Store"));
+    assert!(is_os_junk("Thumbs.db"));
+    assert!(is_os_junk("Desktop.ini"));
+    assert!(is_os_junk("._hidden_macos_resource_fork"));
+}
+
+#[test]
+fn is_os_junk_does_not_block_legitimate_dotfiles() {
+    assert!(!is_os_junk(".pre-commit-config.yaml"));
+    assert!(!is_os_junk(".gitattributes"));
+    assert!(!is_os_junk(".gitleaks.toml"));
+    assert!(!is_os_junk(".gitlab-ci.yml"));
+    assert!(!is_os_junk(".githooks/pre-commit"));
+    assert!(!is_os_junk(".github/workflows/release.yml"));
+    assert!(!is_os_junk("agents/.mdschema"));
+}
+
+#[test]
 fn init_uses_already_exists_skip_reason() {
     let temp_directory = TempDir::new().unwrap();
     std::fs::write(temp_directory.path().join("LICENSE"), "custom\n").unwrap();


### PR DESCRIPTION
## Summary

Closes #28.

`forge init`'s dotfile allowlist permitted only `.githooks/*` and `.github/*`, silently dropping every other hidden file from `templates/init/`:

- `.pre-commit-config.yaml`
- `.gitattributes`
- `.gitleaks.toml`
- `.gitlab-ci.yml`

Surfaced when forge-gm CI failed on `prek` because `forge init` had never deployed the `.pre-commit-config.yaml` despite it living in the embedded templates since #14.

## Fix

Replace the near-total dotfile allowlist with an OS-junk blocklist by basename — `.DS_Store`, `Thumbs.db`, `Desktop.ini`, and macOS `._*` resource forks. Every other template file is deployed.

## Test plan

- [x] `cargo test` — 408 passed (3 new init tests covering the blocklist + the deployment)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `make validate` clean
- [x] `forge init --target /tmp/scratch && ls -la /tmp/scratch` shows `.pre-commit-config.yaml`, `.gitattributes`, `.gitleaks.toml`, `.gitlab-ci.yml`