### PR TITLE
fix: ruff pre-commit hook fires on every commit (#33)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
 
           - id: gitleaks
             name: gitleaks
-            entry: gitleaks detect --no-banner --no-git -s .
+            entry: gitleaks detect --no-banner
             language: system
             pass_filenames: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 
 - `forge init` now deploys all hidden template files (`.pre-commit-config.yaml`, `.gitattributes`, `.gitleaks.toml`, `.gitlab-ci.yml`). The previous near-total dotfile allowlist silently dropped them; replaced with an OS-junk blocklist (`.DS_Store`, `Thumbs.db`, `Desktop.ini`, `._*` resource forks). (#28)
+- `templates/init/.pre-commit-config.yaml` ruff hook drops `pass_filenames: false`, which was bypassing the `types: [python]` filter and forcing ruff to run on every commit (including markdown-only modules without ruff installed). With the flag gone, prek skips the hook when no Python files are staged. (#33)
+- forge-cli's own root `.pre-commit-config.yaml` drops `--no-git -s .` from the gitleaks entry. The flag bypassed git's gitignore, walking 4 GB of cargo `target/` and hanging at 400% CPU. Default invocation respects gitignore.
 
 ### Added
 

--- a/templates/init/.pre-commit-config.yaml
+++ b/templates/init/.pre-commit-config.yaml
@@ -16,9 +16,8 @@ repos:
 
           - id: ruff
             name: ruff check
-            entry: ruff check .
+            entry: ruff check
             language: system
-            pass_filenames: false
             types: [python]
 
           - id: gitleaks


### PR DESCRIPTION
## Summary

Closes #33.

The init template's pre-commit hook for `ruff` fires on every commit, even on markdown-only modules with no Python files staged. Without `ruff` installed, the entire commit fails with `Failed to run hook ruff ... No such file or directory`.

## Root cause

The ruff entry combined two flags that don't compose:

```yaml
- id: ruff
    entry: ruff check .
    pass_filenames: false   # ← bypass
    types: [python]         # ← never consulted
```

`pass_filenames: false` makes pre-commit/prek invoke the hook unconditionally; the `types:` filter is only checked when files are being passed as args. Net effect: ruff runs on every commit regardless of staged file types.

## Fix

Drop `pass_filenames: false` from the ruff entry and change `entry: ruff check .` to `entry: ruff check`. With the default `pass_filenames: true`, prek consults the `types: [python]` filter and **skips the hook entirely when no Python files are staged** — the binary is never invoked, so its absence doesn't matter.

The other potentially-portable hooks were already correctly gated:

| Hook              | Already safe because                                                |
| ----------------- | ------------------------------------------------------------------- |
| `shellcheck`      | `types: [shell]` + default `pass_filenames` → skipped on non-shell  |
| `gitleaks`        | `stages: [pre-push]` → never runs on commit                         |
| `semgrep`         | `stages: [pre-push]` → never runs on commit                         |
| `forge-validate`  | Required for every forge module — install assumption is the point   |

So the issue is genuinely one-line wide. No template overhaul, no bash command-v guards, no upstream supply-chain hooks.

## Bonus

Second commit drops `--no-git -s .` from the gitleaks entry in forge-cli's **own** root `.pre-commit-config.yaml`. The flag bypassed git's gitignore, walking 4 GB of cargo `target/` and hanging at 400% CPU. Default invocation respects gitignore. Unrelated to #33 but discovered during this work.

## Test plan

- [x] `cargo test` — all green
- [x] `make validate` clean (full pre-commit cascade including prek)
- [x] Manual: `prek run --all-files` on a markdown-only stage with ruff uninstalled → ruff hook reports `(no files to check) Skipped` instead of failing
