### PR TITLE
fix: whitelist Claude Code optional frontmatter in skill mdschema (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `forge init` now deploys all hidden template files (`.pre-commit-config.yaml`, `.gitattributes`, `.gitleaks.toml`, `.gitlab-ci.yml`). The previous near-total dotfile allowlist silently dropped them; replaced with an OS-junk blocklist (`.DS_Store`, `Thumbs.db`, `Desktop.ini`, `._*` resource forks). (#28)
 - `templates/init/.pre-commit-config.yaml` ruff hook drops `pass_filenames: false`, which was bypassing the `types: [python]` filter and forcing ruff to run on every commit (including markdown-only modules without ruff installed). With the flag gone, prek skips the hook when no Python files are staged. (#33)
 - forge-cli's own root `.pre-commit-config.yaml` drops `--no-git -s .` from the gitleaks entry. The flag bypassed git's gitignore, walking 4 GB of cargo `target/` and hanging at 400% CPU. Default invocation respects gitignore.
+- `templates/init/skills/.mdschema` whitelists 12 Claude Code optional `SKILL.md` frontmatter fields (`when_to_use`, `argument-hint`, `arguments`, `allowed-tools`, `disable-model-invocation`, `user-invocable`, `model`, `effort`, `context`, `agent`, `paths`, `shell`). Modules that lift those fields from a `SKILL.yaml` sidecar to top-level frontmatter (the natural authoring path now that Claude Code parses them natively) no longer fail validation with `Unknown frontmatter field`. `hooks` is omitted because mdschema lacks an `object` type for the nested map. (#40)
 
 ### Added
 

--- a/src/cli/validate/tests.rs
+++ b/src/cli/validate/tests.rs
@@ -51,6 +51,38 @@ fn check_module_yaml_skips_when_no_module_yaml() {
     assert!(result.errors.is_empty());
 }
 
+#[test]
+fn skill_directory_accepts_claude_code_optional_fields() {
+    let temp_directory = TempDir::new().unwrap();
+    let skill_dir = temp_directory.path().join("ExampleSkill");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+
+    let skill_md = "---\n\
+name: ExampleSkill\n\
+description: \"Test skill using Claude Code optional frontmatter fields.\"\n\
+version: 0.1.0\n\
+argument-hint: \"[year]\"\n\
+allowed-tools: [Read, Bash]\n\
+model: claude-opus-4-7\n\
+effort: high\n\
+when_to_use: \"When the user asks for X.\"\n\
+---\n\
+\n\
+# ExampleSkill\n\
+\n\
+Body content for the test skill.\n";
+    std::fs::write(skill_dir.join("SKILL.md"), skill_md).unwrap();
+
+    let mut result = ActionResult::new();
+    check::skill_directory(&skill_dir, &mut result).unwrap();
+
+    assert!(
+        result.errors.is_empty(),
+        "Claude Code optional skill fields should validate cleanly: {:?}",
+        result.errors
+    );
+}
+
 // --- tools.rs native checks ---
 
 #[test]

--- a/templates/init/skills/.mdschema
+++ b/templates/init/skills/.mdschema
@@ -1,11 +1,54 @@
 frontmatter:
     fields:
+        # forge convention: required for module skills
         - name: name
           type: string
         - name: description
           type: string
         - name: version
           type: string
+
+        # Claude Code optional fields
+        # https://code.claude.com/docs/en/skills#frontmatter-reference
+        # `hooks` is intentionally omitted: mdschema has no `object` type yet,
+        # and a hooks map (`{ PreToolUse: [...] }`) cannot be represented as
+        # one of string|number|boolean|array|date.
+        - name: when_to_use
+          type: string
+          optional: true
+        - name: argument-hint
+          type: string
+          optional: true
+        - name: arguments
+          type: array
+          optional: true
+        - name: allowed-tools
+          type: array
+          optional: true
+        - name: disable-model-invocation
+          type: boolean
+          optional: true
+        - name: user-invocable
+          type: boolean
+          optional: true
+        - name: model
+          type: string
+          optional: true
+        - name: effort
+          type: string
+          optional: true
+        - name: context
+          type: string
+          optional: true
+        - name: agent
+          type: string
+          optional: true
+        - name: paths
+          type: array
+          optional: true
+        - name: shell
+          type: string
+          optional: true
 
 heading_rules:
     no_skip_levels: true


### PR DESCRIPTION
## Summary

Closes #40.

The init template's `skills/.mdschema` previously only whitelisted `name`, `description`, `version`. Claude Code documents thirteen optional `SKILL.md` frontmatter fields ([upstream reference][CCFR]) that modules want to use at top-level frontmatter rather than carry in a `SKILL.yaml` sidecar. Any module adopting that pattern fails `forge validate` with `Unknown frontmatter field: argument-hint`.

## Fix

Extend `templates/init/skills/.mdschema` to whitelist twelve of the thirteen Claude Code optional fields, all marked `optional: true`:

`when_to_use`, `argument-hint`, `arguments`, `allowed-tools`, `disable-model-invocation`, `user-invocable`, `model`, `effort`, `context`, `agent`, `paths`, `shell`.

`hooks` is intentionally omitted: mdschema's `FieldType` enum is `string | number | boolean | array | date`, so the nested map (`{ PreToolUse: [...] }`) cannot be expressed. Documented inline in the schema with a comment pointing at the upstream constraint.

The schema ships two ways:

- Embedded into the `forge` binary via rust-embed at `src/cli/validate/templates.rs` — used as the fallback when consumer modules don't ship their own `.mdschema`
- Deployed by `forge init` to new modules at `skills/.mdschema`

Both paths benefit from a single edit.

## Test plan

- [x] `cargo test` — 243 passed (1 new unit test: `skill_directory_accepts_claude_code_optional_fields` constructs a `SKILL.md` with `argument-hint`, `allowed-tools`, `model`, `effort`, `when_to_use` and asserts validation passes)
- [x] `make validate` clean (full pre-commit cascade including `forge validate` against forge-cli itself)

## Reference

forge-finance applied the same fix locally in commit [`6fce3ae`][CMT]. Landing it here means consumer modules pulling the updated init template no longer need to carry a forked schema.

[CCFR]: https://code.claude.com/docs/en/skills#frontmatter-reference
[CMT]: https://github.com/N4M3Z/forge-finance/commit/6fce3ae
