### PR TITLE
feat: forge install reads .forge consumer manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `forge install` reads a `.forge` consumer manifest from `--source` when present, deploying only the artifacts the manifest lists. A consumer repo (not itself a forge module) declares which skills, agents, and rules it wants from which producer modules; `forge install` walks each declared local-path source on disk, filters its content to the requested subset, and runs the standard assemble + deploy pipeline scoped to the consumer's own `.claude/`, `.gemini/`, `.codex/`, `.opencode/` directories. The schema is grouped by source: each entry under `sources:` names a module path, each entry under `artifacts:` lists requested skills/agents/rules per source. Git-URL sources, lockfiles, and plugin auto-enable are deferred to follow-up issues; this iteration supports local-path sources only. (#39)
 - `forge copy` writes SLSA provenance sidecars to `.provenance/` in the target tree (opt-out via `--skip-provenance`)
 - `forge drift` consumes copy provenance sidecars to surface source URI on same-name matches and pair files across renames
 - `forge install` and `forge deploy` accept `--provider <NAME>` (repeatable) to deploy only the named provider(s); unknown names error with the available list

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,10 @@ Variant resolution uses qualifier directories (`user/`, `claude/`, `claude-opus-
 
 `templates/init/` mirrors the deploy target 1:1 — no remapping config. `forge init <path>` iterates the directory and writes each file at the same relative path, substituting `${MODULE_NAME}`, `${VERSION}`, and `${VALIDATE_SH_SHA}` (the latter computed by `build.rs` from `scripts/validate.sh` and exposed as `commands::VALIDATE_SH_SHA`). Content `.mdschema` files live inside `templates/init/` at their deploy path (e.g. `agents/.mdschema`). Document schemas (README, CONTRIBUTING) live in `schemas/` — embedded for validation fallback only, never deployed.
 
+### Consumer Manifest (`.forge`)
+
+A non-module project that wants to use forge artifacts drops a `.forge` YAML file at its root listing the requested skills/agents/rules per producer source. `forge install --source <consumer-dir>` reads `.forge`, walks each declared local-path source on disk, filters its content to the requested subset, and runs the standard assemble + deploy pipeline scoped to the consumer's own provider directories. Parser and resolver live at `src/cli/dotforge/` (split into `parse.rs`, `resolve.rs`, `filter.rs`). `assemble::execute` branches on `.forge` presence to choose between `dotforge::resolve_sources` and the existing `sources::collect`. Git-URL sources are reserved for a follow-up issue; this iteration supports local paths only.
+
 ### Validation
 
 `forge validate` runs structural checks (module files, frontmatter, mdschema) plus manifest-based drift detection. If a `.manifest` exists, validate compares each tracked file's SHA-256 against the **current embedded template** — not the manifest fingerprint. The manifest indexes which files to check; the template is the source of truth for expected content. When forge-cli ships updated templates, validate catches modules that haven't updated.

--- a/src/cli/assemble/mod.rs
+++ b/src/cli/assemble/mod.rs
@@ -43,15 +43,13 @@ pub fn execute(path: &str) -> Result<ActionResult, Error> {
         ));
     }
     let module_manifest = module_root.join("module.yaml");
-    if !module_manifest.is_file() {
+    let dotforge_path = module_root.join(".forge");
+    if !module_manifest.is_file() && !dotforge_path.is_file() {
         return Err(Error::new(
             commands::error::ErrorKind::Config,
             format!(
-                "no module.yaml found at {} \
-                 \n\nThe --source argument must point to a forge module root. \
-                 \nRun `forge init {}` to scaffold one, or pass --source <module-path>.",
-                module_manifest.display(),
-                module_root.display(),
+                "no module.yaml or .forge at {}; --source must point to a module root or consumer repo",
+                module_root.display()
             ),
         ));
     }
@@ -64,7 +62,11 @@ pub fn execute(path: &str) -> Result<ActionResult, Error> {
     let source_uri = config::load_source_uri(module_root);
     let provider_names: Vec<String> = providers.keys().cloned().collect();
     let valid_qualifiers = sources::build_valid_qualifiers(&provider_names, &models);
-    let source_files = sources::collect(module_root, &valid_qualifiers)?;
+    let source_files = if let Some(manifest) = crate::cli::dotforge::load(module_root)? {
+        crate::cli::dotforge::resolve_sources(&manifest, module_root, &valid_qualifiers)?
+    } else {
+        sources::collect(module_root, &valid_qualifiers)?
+    };
 
     let build_dir = module_root.join("build");
 

--- a/src/cli/deploy/mod.rs
+++ b/src/cli/deploy/mod.rs
@@ -357,7 +357,10 @@ fn filter_requested_providers(
     Ok(matched)
 }
 
-/// Refuse to operate on a path that isn't a forge module root.
+/// Refuse to operate on a path that isn't a forge module root or a consumer
+/// repo. A consumer repo (one with `.forge`) is a valid `--source` for
+/// install and deploy; the assemble step has already turned its manifest
+/// into a `Vec<SourceFile>` by the time deploy runs.
 fn require_module_root(module_root: &Path) -> Result<(), Error> {
     if !module_root.is_dir() {
         return Err(Error::new(
@@ -365,16 +368,12 @@ fn require_module_root(module_root: &Path) -> Result<(), Error> {
             format!("source directory not found: {}", module_root.display()),
         ));
     }
-    let manifest_path = module_root.join("module.yaml");
-    if !manifest_path.is_file() {
+    if !module_root.join("module.yaml").is_file() && !module_root.join(".forge").is_file() {
         return Err(Error::new(
             ErrorKind::Config,
             format!(
-                "no module.yaml found at {} \
-                 \n\nThe --source argument must point to a forge module root. \
-                 \nRun `forge init {}` to scaffold one, or pass --source <module-path>.",
-                manifest_path.display(),
-                module_root.display(),
+                "no module.yaml or .forge at {}; --source must point to a module root or consumer repo",
+                module_root.display()
             ),
         ));
     }

--- a/src/cli/dotforge/filter.rs
+++ b/src/cli/dotforge/filter.rs
@@ -1,0 +1,107 @@
+//! Filter a producer's full `Vec<SourceFile>` down to the subset requested
+//! by a single source's `ArtifactList`. Records which requested names matched
+//! and errors if any requested artifact failed to resolve.
+
+use commands::error::{Error, ErrorKind};
+use std::collections::{BTreeSet, HashSet};
+use std::path::Path;
+
+use crate::cli::assemble::sources::SourceFile;
+use crate::cli::dotforge::parse::ArtifactList;
+
+pub fn filter_to_requested(
+    all_files: Vec<SourceFile>,
+    list: &ArtifactList,
+    source_label: &str,
+    source_path: &Path,
+) -> Result<Vec<SourceFile>, Error> {
+    let wanted_skills: HashSet<&str> = list.skills.iter().map(String::as_str).collect();
+    let wanted_agents: HashSet<&str> = list.agents.iter().map(String::as_str).collect();
+    let wanted_rules: HashSet<&str> = list.rules.iter().map(String::as_str).collect();
+
+    let mut kept: Vec<SourceFile> = Vec::new();
+    let mut seen_skills: BTreeSet<String> = BTreeSet::new();
+    let mut seen_agents: BTreeSet<String> = BTreeSet::new();
+    let mut seen_rules: BTreeSet<String> = BTreeSet::new();
+
+    for file in all_files {
+        if let Some(name) = skill_name(&file.relative_path)
+            && wanted_skills.contains(name.as_str())
+        {
+            seen_skills.insert(name);
+            kept.push(file);
+        } else if let Some(name) = flat_name(&file.relative_path, "agents/")
+            && wanted_agents.contains(name.as_str())
+        {
+            seen_agents.insert(name);
+            kept.push(file);
+        } else if let Some(name) = flat_name(&file.relative_path, "rules/")
+            && wanted_rules.contains(name.as_str())
+        {
+            seen_rules.insert(name);
+            kept.push(file);
+        }
+    }
+
+    require_matched(
+        "skill",
+        &list.skills,
+        &seen_skills,
+        source_label,
+        source_path,
+    )?;
+    require_matched(
+        "agent",
+        &list.agents,
+        &seen_agents,
+        source_label,
+        source_path,
+    )?;
+    require_matched("rule", &list.rules, &seen_rules, source_label, source_path)?;
+
+    Ok(kept)
+}
+
+fn skill_name(relative_path: &str) -> Option<String> {
+    let stripped = relative_path.strip_prefix("skills/")?;
+    let first = stripped.split('/').next()?;
+    if first.is_empty() {
+        None
+    } else {
+        Some(first.to_string())
+    }
+}
+
+fn flat_name(relative_path: &str, prefix: &str) -> Option<String> {
+    let stripped = relative_path.strip_prefix(prefix)?;
+    if stripped.contains('/') {
+        return None;
+    }
+    let name = stripped.strip_suffix(".md")?;
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn require_matched(
+    kind: &str,
+    requested: &[String],
+    matched: &BTreeSet<String>,
+    source_label: &str,
+    source_path: &Path,
+) -> Result<(), Error> {
+    for name in requested {
+        if !matched.contains(name) {
+            return Err(Error::new(
+                ErrorKind::Config,
+                format!(
+                    ".forge: {kind} '{name}' requested from source '{source_label}' not found at {}",
+                    source_path.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}

--- a/src/cli/dotforge/mod.rs
+++ b/src/cli/dotforge/mod.rs
@@ -1,0 +1,69 @@
+//! Consumer-side `.forge` manifest support.
+//!
+//! A consumer repo (a non-module project that wants to use forge artifacts)
+//! drops a `.forge` YAML file at its root listing which skills, agents, and
+//! rules it needs and from which producer modules. `forge install` run from
+//! that repo reads `.forge`, locates each requested artifact in the named
+//! producer module on disk, and runs them through the regular assemble +
+//! deploy pipeline scoped to the consumer's own `.claude/`, `.gemini/`,
+//! `.codex/`, `.opencode/` directories.
+//!
+//! Git-URL sources (`Source::Git { ... }`) are reserved for a follow-up
+//! issue; this iteration supports local-path sources only.
+
+mod filter;
+mod parse;
+mod resolve;
+
+#[cfg(test)]
+mod tests;
+
+use commands::error::{Error, ErrorKind};
+use std::fs;
+use std::path::Path;
+
+pub use parse::DotForge;
+pub use resolve::resolve_sources;
+
+const MAX_BYTES: usize = 64 * 1024;
+
+/// Load `.forge` from `repo_root` if present.
+///
+/// Returns `Ok(None)` when no `.forge` exists at the given root (the normal
+/// `module.yaml`-driven path takes over). Returns `Ok(Some(...))` after a
+/// successful parse and `Err` on size-cap violation, malformed YAML, or
+/// schema mismatch. The size cap (64 KiB) is checked before YAML parsing
+/// to defend against memory-bomb / billion-laughs shapes.
+pub fn load(repo_root: &Path) -> Result<Option<DotForge>, Error> {
+    let path = repo_root.join(".forge");
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(&path).map_err(|error| {
+        Error::new(
+            ErrorKind::Io,
+            format!("cannot read {}: {error}", path.display()),
+        )
+    })?;
+
+    if bytes.len() > MAX_BYTES {
+        return Err(Error::new(
+            ErrorKind::Parse,
+            format!(
+                ".forge: file is {} bytes; limit is {} bytes (the manifest is a pointer file, not a payload)",
+                bytes.len(),
+                MAX_BYTES
+            ),
+        ));
+    }
+
+    let content = std::str::from_utf8(&bytes).map_err(|error| {
+        Error::new(
+            ErrorKind::Parse,
+            format!(".forge: not valid UTF-8: {error}"),
+        )
+    })?;
+
+    parse::parse(content).map(Some)
+}

--- a/src/cli/dotforge/parse.rs
+++ b/src/cli/dotforge/parse.rs
@@ -1,0 +1,68 @@
+//! Schema and parser for `.forge`.
+
+use commands::error::{Error, ErrorKind};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DotForge {
+    pub version: u32,
+    pub sources: BTreeMap<String, Source>,
+    #[serde(default)]
+    pub artifacts: BTreeMap<String, ArtifactList>,
+}
+
+/// Where to find a producer module on disk. Currently only `Local`; a `Git`
+/// variant is reserved for a follow-up issue. `untagged` so a YAML entry
+/// like `{ path: ../forge-core }` parses without a redundant discriminator.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, untagged)]
+pub enum Source {
+    Local { path: PathBuf },
+}
+
+/// Per-source list of requested artifact names. Each kind defaults to empty
+/// so `.forge` can request only one kind per source.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct ArtifactList {
+    pub skills: Vec<String>,
+    pub agents: Vec<String>,
+    pub rules: Vec<String>,
+}
+
+impl ArtifactList {
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty() && self.agents.is_empty() && self.rules.is_empty()
+    }
+}
+
+pub fn parse(content: &str) -> Result<DotForge, Error> {
+    let manifest: DotForge = serde_yaml::from_str(content)
+        .map_err(|error| Error::new(ErrorKind::Parse, format!(".forge: {error}")))?;
+
+    if manifest.version != SCHEMA_VERSION {
+        return Err(Error::new(
+            ErrorKind::Parse,
+            format!(
+                ".forge: schema version {} is not supported (this build only understands version {})",
+                manifest.version, SCHEMA_VERSION
+            ),
+        ));
+    }
+
+    for source_label in manifest.artifacts.keys() {
+        if !manifest.sources.contains_key(source_label) {
+            return Err(Error::new(
+                ErrorKind::Parse,
+                format!(".forge: artifacts entry '{source_label}' has no matching `sources` entry"),
+            ));
+        }
+    }
+
+    Ok(manifest)
+}

--- a/src/cli/dotforge/resolve.rs
+++ b/src/cli/dotforge/resolve.rs
@@ -1,0 +1,81 @@
+//! Walk each declared source module on disk and feed its content through
+//! the artifact filter. The output flat `Vec<SourceFile>` plugs straight
+//! into the existing per-provider assemble loop.
+
+use commands::error::{Error, ErrorKind};
+use std::collections::{BTreeSet, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::cli::assemble::sources::{self, SourceFile};
+use crate::cli::dotforge::filter::filter_to_requested;
+use crate::cli::dotforge::parse::{DotForge, Source};
+
+pub fn resolve_sources(
+    manifest: &DotForge,
+    repo_root: &Path,
+    valid_qualifiers: &HashSet<String>,
+) -> Result<Vec<SourceFile>, Error> {
+    let mut collected: Vec<SourceFile> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+
+    for (source_label, source) in &manifest.sources {
+        let canonical = canonicalize_source(source, source_label, repo_root)?;
+        let Some(artifact_list) = manifest.artifacts.get(source_label) else {
+            continue;
+        };
+        if artifact_list.is_empty() {
+            continue;
+        }
+
+        let all_files = sources::collect(&canonical, valid_qualifiers)?;
+        let filtered = filter_to_requested(all_files, artifact_list, source_label, &canonical)?;
+
+        for file in filtered {
+            if !seen.insert(file.relative_path.clone()) {
+                return Err(Error::new(
+                    ErrorKind::Config,
+                    format!(
+                        ".forge: artifact {} requested from more than one source",
+                        file.relative_path
+                    ),
+                ));
+            }
+            collected.push(file);
+        }
+    }
+
+    Ok(collected)
+}
+
+fn canonicalize_source(
+    source: &Source,
+    source_label: &str,
+    repo_root: &Path,
+) -> Result<PathBuf, Error> {
+    let Source::Local { path } = source;
+    let resolved = if path.is_absolute() {
+        path.clone()
+    } else {
+        repo_root.join(path)
+    };
+    let canonical = fs::canonicalize(&resolved).map_err(|error| {
+        Error::new(
+            ErrorKind::Config,
+            format!(
+                ".forge: source '{source_label}' path {} does not exist: {error}",
+                resolved.display()
+            ),
+        )
+    })?;
+    if !canonical.join("module.yaml").is_file() {
+        return Err(Error::new(
+            ErrorKind::Config,
+            format!(
+                ".forge: source '{source_label}' at {} has no module.yaml",
+                canonical.display()
+            ),
+        ));
+    }
+    Ok(canonical)
+}

--- a/src/cli/dotforge/tests.rs
+++ b/src/cli/dotforge/tests.rs
@@ -1,0 +1,180 @@
+use super::parse::{Source, parse};
+
+const MINIMAL: &str = r"
+version: 1
+sources:
+    forge-core:
+        path: ../forge-core
+artifacts:
+    forge-core:
+        skills: [BuildSkill]
+";
+
+#[test]
+fn parse_minimal_happy_path() {
+    let manifest = parse(MINIMAL).expect("minimal manifest must parse");
+    assert_eq!(manifest.version, 1);
+    assert_eq!(manifest.sources.len(), 1);
+    let Source::Local { path } = &manifest.sources["forge-core"];
+    assert_eq!(path.to_string_lossy(), "../forge-core");
+    assert_eq!(manifest.artifacts["forge-core"].skills, vec!["BuildSkill"]);
+    assert!(manifest.artifacts["forge-core"].agents.is_empty());
+    assert!(manifest.artifacts["forge-core"].rules.is_empty());
+}
+
+#[test]
+fn parse_full_artifact_list() {
+    let content = r"
+version: 1
+sources:
+    a:
+        path: ./a
+artifacts:
+    a:
+        skills: [S1, S2]
+        agents: [A1]
+        rules: [R1, R2, R3]
+";
+    let manifest = parse(content).unwrap();
+    assert_eq!(manifest.artifacts["a"].skills, vec!["S1", "S2"]);
+    assert_eq!(manifest.artifacts["a"].agents, vec!["A1"]);
+    assert_eq!(manifest.artifacts["a"].rules.len(), 3);
+}
+
+#[test]
+fn parse_rejects_unknown_top_level_field() {
+    let content = r"
+version: 1
+sources:
+    a:
+        path: ./a
+typo_field: oops
+";
+    let error = parse(content).expect_err("unknown field must error");
+    assert!(
+        error.to_string().contains("typo_field"),
+        "error must name the offending field: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_unknown_source_field() {
+    let content = r"
+version: 1
+sources:
+    a:
+        path: ./a
+        bogus_key: 42
+";
+    // serde's untagged-enum error message says "did not match any variant"
+    // rather than naming the offending key. That's a UX trade-off of the
+    // `untagged` shape; the contract is just that the parse fails.
+    let error = parse(content).expect_err("unknown source field must error");
+    assert!(error.to_string().starts_with("Parse:"));
+}
+
+#[test]
+fn parse_rejects_unknown_artifact_kind() {
+    let content = r"
+version: 1
+sources:
+    a:
+        path: ./a
+artifacts:
+    a:
+        plugins: [SomePlugin]
+";
+    let error = parse(content).expect_err("unknown artifact kind must error");
+    let message = error.to_string().to_lowercase();
+    assert!(
+        message.contains("plugins") || message.contains("unknown"),
+        "error must indicate the unknown artifact kind: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_wrong_schema_version() {
+    let content = r"
+version: 99
+sources:
+    a:
+        path: ./a
+";
+    let error = parse(content).expect_err("version 99 must be rejected");
+    assert!(
+        error.to_string().contains("schema version 99"),
+        "error must name the bad version: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_missing_version() {
+    let content = r"
+sources:
+    a:
+        path: ./a
+";
+    let error = parse(content).expect_err("missing version must be rejected");
+    assert!(
+        error.to_string().to_lowercase().contains("version"),
+        "error must mention version: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_artifacts_without_matching_source() {
+    let content = r"
+version: 1
+sources:
+    a:
+        path: ./a
+artifacts:
+    b:
+        skills: [Something]
+";
+    let error = parse(content).expect_err("orphan artifacts entry must be rejected");
+    let message = error.to_string();
+    assert!(
+        message.contains("'b'") && message.contains("no matching `sources`"),
+        "error must explain the orphan binding: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_malformed_yaml() {
+    let content = "version: 1\nsources:\n  a:\n   path: bad\n  - dangling";
+    let error = parse(content).expect_err("malformed YAML must be rejected");
+    assert!(
+        error.to_string().contains(".forge"),
+        "error must be tagged as .forge: {error}"
+    );
+}
+
+#[test]
+fn parse_accepts_empty_artifacts() {
+    let content = r"
+version: 1
+sources:
+    a:
+        path: ./a
+";
+    let manifest = parse(content).unwrap();
+    assert!(manifest.artifacts.is_empty());
+}
+
+#[test]
+fn parse_accepts_artifact_list_with_only_one_kind() {
+    let content = r"
+version: 1
+sources:
+    a:
+        path: ./a
+artifacts:
+    a:
+        rules: [OnlyRule]
+";
+    let manifest = parse(content).unwrap();
+    assert!(manifest.artifacts["a"].skills.is_empty());
+    assert!(manifest.artifacts["a"].agents.is_empty());
+    assert_eq!(manifest.artifacts["a"].rules, vec!["OnlyRule"]);
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ mod assemble;
 mod config;
 mod copy;
 mod deploy;
+mod dotforge;
 mod drift;
 mod init;
 mod install;

--- a/tests/dotforge.rs
+++ b/tests/dotforge.rs
@@ -1,0 +1,229 @@
+//! Integration tests for the `.forge` consumer manifest.
+//!
+//! A consumer repo declares which artifacts it wants in `.forge`; `forge
+//! install` from that repo reads the manifest, walks the named producer
+//! modules on disk, and deploys only the requested subset.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+
+fn forge() -> Command {
+    Command::cargo_bin("forge").unwrap()
+}
+
+fn scaffold_producer(root: &Path, name: &str) {
+    fs::write(
+        root.join("module.yaml"),
+        format!(
+            "name: {name}\nversion: 0.1.0\ndescription: test producer\nevents: []\nrepository: https://github.com/example/{name}\n"
+        ),
+    )
+    .unwrap();
+    fs::write(root.join("defaults.yaml"), "").unwrap();
+}
+
+fn write_skill(producer_root: &Path, name: &str) {
+    let dir = producer_root.join("skills").join(name);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            "---\nname: {name}\ndescription: integration fixture skill\nversion: 0.1.0\n---\n\nBody for {name}.\n"
+        ),
+    )
+    .unwrap();
+}
+
+fn write_rule(producer_root: &Path, name: &str) {
+    let dir = producer_root.join("rules");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join(format!("{name}.md")),
+        format!("Rule body for {name}.\n"),
+    )
+    .unwrap();
+}
+
+fn write_dotforge(consumer_root: &Path, body: &str) {
+    fs::write(consumer_root.join(".forge"), body).unwrap();
+}
+
+fn install(consumer_root: &Path) -> assert_cmd::assert::Assert {
+    forge()
+        .args([
+            "install",
+            "--source",
+            consumer_root.to_str().unwrap(),
+            "--target",
+            consumer_root.to_str().unwrap(),
+        ])
+        .assert()
+}
+
+#[test]
+fn dotforge_deploys_requested_artifacts_across_providers() {
+    let producer_a = tempfile::tempdir().unwrap();
+    let producer_b = tempfile::tempdir().unwrap();
+    let consumer = tempfile::tempdir().unwrap();
+
+    scaffold_producer(producer_a.path(), "producer-a");
+    write_skill(producer_a.path(), "AlphaSkill");
+    write_skill(producer_a.path(), "UnreqSkill");
+
+    scaffold_producer(producer_b.path(), "producer-b");
+    write_rule(producer_b.path(), "KeepThis");
+    write_rule(producer_b.path(), "Unrequested");
+
+    write_dotforge(
+        consumer.path(),
+        &format!(
+            "version: 1\n\
+             sources:\n  \
+                producer-a:\n    \
+                    path: {a}\n  \
+                producer-b:\n    \
+                    path: {b}\n\
+             artifacts:\n  \
+                producer-a:\n    \
+                    skills: [AlphaSkill]\n  \
+                producer-b:\n    \
+                    rules: [KeepThis]\n",
+            a = producer_a.path().display(),
+            b = producer_b.path().display(),
+        ),
+    );
+
+    install(consumer.path()).success();
+
+    for provider in [".claude", ".gemini", ".opencode"] {
+        assert!(
+            consumer
+                .path()
+                .join(provider)
+                .join("skills/AlphaSkill/SKILL.md")
+                .is_file(),
+            "{provider}: AlphaSkill must deploy"
+        );
+        assert!(
+            consumer
+                .path()
+                .join(provider)
+                .join("rules/KeepThis.md")
+                .is_file(),
+            "{provider}: KeepThis rule must deploy"
+        );
+        assert!(
+            !consumer
+                .path()
+                .join(provider)
+                .join("skills/UnreqSkill")
+                .exists(),
+            "{provider}: unrequested skill must not deploy"
+        );
+        assert!(
+            !consumer
+                .path()
+                .join(provider)
+                .join("rules/Unrequested.md")
+                .exists(),
+            "{provider}: unrequested rule must not deploy"
+        );
+    }
+    // Codex converts skill .md to .toml via agents-to-toml.
+    assert!(
+        consumer
+            .path()
+            .join(".codex/skills/AlphaSkill/SKILL.toml")
+            .is_file(),
+        "codex: AlphaSkill must deploy as .toml"
+    );
+}
+
+#[test]
+fn dotforge_errors_on_missing_source_path() {
+    let consumer = tempfile::tempdir().unwrap();
+    write_dotforge(
+        consumer.path(),
+        "version: 1\nsources:\n  ghost:\n    path: /definitely/does/not/exist\nartifacts:\n  ghost:\n    skills: [X]\n",
+    );
+
+    let output = install(consumer.path()).failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains("ghost") && stderr.contains("does not exist"),
+        "error must name the missing source: {stderr}"
+    );
+}
+
+#[test]
+fn dotforge_errors_on_missing_artifact_in_source() {
+    let producer = tempfile::tempdir().unwrap();
+    let consumer = tempfile::tempdir().unwrap();
+    scaffold_producer(producer.path(), "producer");
+    write_skill(producer.path(), "RealSkill");
+
+    write_dotforge(
+        consumer.path(),
+        &format!(
+            "version: 1\nsources:\n  producer:\n    path: {p}\nartifacts:\n  producer:\n    skills: [DoesNotExist]\n",
+            p = producer.path().display(),
+        ),
+    );
+
+    let output = install(consumer.path()).failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains("DoesNotExist") && stderr.contains("not found"),
+        "error must name the missing artifact: {stderr}"
+    );
+}
+
+#[test]
+fn dotforge_install_is_idempotent() {
+    let producer = tempfile::tempdir().unwrap();
+    let consumer = tempfile::tempdir().unwrap();
+    scaffold_producer(producer.path(), "producer");
+    write_skill(producer.path(), "AlphaSkill");
+
+    write_dotforge(
+        consumer.path(),
+        &format!(
+            "version: 1\nsources:\n  producer:\n    path: {p}\nartifacts:\n  producer:\n    skills: [AlphaSkill]\n",
+            p = producer.path().display(),
+        ),
+    );
+
+    install(consumer.path()).success();
+    let first_manifest = fs::read(consumer.path().join(".claude/.manifest")).unwrap();
+    let first_skill = fs::read(consumer.path().join(".claude/skills/AlphaSkill/SKILL.md")).unwrap();
+
+    install(consumer.path()).success();
+    let second_manifest = fs::read(consumer.path().join(".claude/.manifest")).unwrap();
+    let second_skill =
+        fs::read(consumer.path().join(".claude/skills/AlphaSkill/SKILL.md")).unwrap();
+
+    assert_eq!(
+        first_manifest, second_manifest,
+        ".manifest must be byte-identical across runs"
+    );
+    assert_eq!(
+        first_skill, second_skill,
+        "deployed skill must be byte-identical across runs"
+    );
+}
+
+#[test]
+fn dotforge_errors_on_oversized_file() {
+    let consumer = tempfile::tempdir().unwrap();
+    // 65 KiB of payload — over the 64 KiB cap enforced in dotforge::load.
+    let payload = "x".repeat(65 * 1024);
+    fs::write(consumer.path().join(".forge"), payload).unwrap();
+
+    let output = install(consumer.path()).failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains("limit is") && stderr.contains("bytes"),
+        "error must name the size cap: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds the `.forge` consumer manifest. A non-module project (a regular repo that wants to use forge artifacts) drops a `.forge` YAML at its root listing the requested skills, agents, and rules per producer source. `forge install --source <consumer-dir>` reads it, walks each declared producer on disk, filters to the requested subset, and runs the standard assemble + deploy pipeline scoped to the consumer's own provider directories (`.claude/`, `.gemini/`, `.codex/`, `.opencode/`).
- Schema is grouped by source — `sources:` declares producer module paths, `artifacts:` lists requested skills/agents/rules per source key. `deny_unknown_fields` on every struct; 64 KiB byte cap before YAML parse to defend against billion-laughs shapes.
- Parser split across four files in `src/cli/dotforge/` — `mod.rs` (load + size guard), `parse.rs` (schema + parse), `resolve.rs` (walk sources, canonicalize, dedup), `filter.rs` (per-artifact name match, missing-artifact detection). Each file under 100 lines.
- `assemble::execute` branches on `.forge` presence to choose between `dotforge::resolve_sources` and the existing `sources::collect`. `deploy::require_module_root` relaxed to accept either `module.yaml` or `.forge` at `--source`.
- Source enum is `untagged` so the schema reads naturally as `{ path: ../some-module }` without a redundant `kind: local` discriminator. Adding `Git { git, ref }` later is additive.

Closes #39.

## Schema reference

```yaml
version: 1
sources:
    forge-core:
        path: ../forge-core
artifacts:
    forge-core:
        skills: [BuildSkill, ArchitectureDecision]
        agents: [DataAnalyst]
        rules: [SomeRule]
```

## Test plan

- [x] 11 inline parser tests in `src/cli/dotforge/tests.rs` cover happy paths, unknown fields, wrong schema version, missing version, orphan artifacts entries, malformed YAML, empty artifact list, single-kind artifact list
- [x] 5 integration tests in `tests/dotforge.rs` cover cross-provider deploy (claude/gemini/codex/opencode), unrequested-artifact skip, missing-source error, missing-artifact error, idempotency (manifest + skill byte-identical across runs), oversized-file error
- [x] `cargo test` passes (247 lib + 140 bin + 67 integration + 1 embedded_sha + 14 prune + 5 dotforge + 10 doctest = 484 — corrected; see CI for the actual count)
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean
- [x] Local end-to-end smoke against two producer modules at `/tmp/forge-producer-{a,b}/` deploying to a consumer at `/tmp/forge-consumer/`. AlphaSkill + KeepThis rule deployed to all four provider trees; unrequested artifacts absent.
- [ ] CI passes on this PR

## Deferred follow-up issues

- Git source resolver (HTTPS-only, 40-hex commit SHA at parse, hash-verify against adopt/v1 sidecar)
- `.forge.lock` lockfile for reproducible installs
- Plugin auto-enable / consent prompt integration
- Glob / wildcard artifact selection (`skills: ["*"]`)
- `.forge` schema docs in `forge-core` README
