### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-22
+
 ### Fixed
 
 - `forge install` now prunes deployed skill, agent, and rule directories absent from source. Stale directories (renamed, folded, or deleted upstream) used to keep loading into Claude / Gemini / Codex / OpenCode sessions, shadowing renames. Pruned content moves to `<target>/.trash/<UTC-ts>/` for recoverability; restore with `mv`, reclaim with `rm -rf`. Empty parent directories are walked and removed up to but not including the provider target root. Opt out with `--no-prune`; preview with `--dry-run`. Locally modified files (deployed SHA-256 no longer matches the manifest fingerprint) are skipped with a warning; pass `--force` to prune them anyway. `forge clean` uses the same quarantine path for consistency. The substring-collision bug in `is_owned_by_module` (which previously matched `Prompts` against `PublishPrompts` and let two modules named `forge-core` at different repositories prune each other's files) is fixed via structured `(host, owner, repo)` equality on the source URI. (#45)
@@ -34,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - `forge install`, `forge deploy`, `forge clean` refuse to operate on a directory without `module.yaml`; the error names the missing file and the corrective `--source` invocation
 - The YAML deep-merge "type conflict" warning now identifies the conflicting key path and the involved YAML types
 - `forge install --help` lists the available providers, explains the `--target` per-provider join, and shows two example invocations
+- Codex default models refreshed to currently-supported GPT-5 Codex variants in `defaults.yaml` and `config/models.yaml`. (#41, #51)
 
 ### Removed
 
@@ -128,7 +131,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - INSTALL.md following Mintlify install.md standard
 - 28 ADRs documenting architecture decisions
 
-[Unreleased]: https://github.com/N4M3Z/forge-cli/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/N4M3Z/forge-cli/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/N4M3Z/forge-cli/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/N4M3Z/forge-cli/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/N4M3Z/forge-cli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/N4M3Z/forge-cli/compare/v0.1.0...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forge-cli"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "EUPL-1.2"
 repository = "https://github.com/N4M3Z/forge-cli"


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` from 0.3.1 to 0.3.2
- Cut CHANGELOG `[Unreleased]` to `[0.3.2] - 2026-05-22`; new empty `[Unreleased]` opens above
- Add Changed entry rolling up the codex default-models refreshes (#41, #51)

What ships in 0.3.2:

**Fixed**
- `forge install` prunes deployed dirs absent from source; quarantines to `<target>/.trash/<UTC-ts>/`; mod-protected via manifest fingerprint; substring-collision bug in `is_owned_by_module` repaired (#45)
- `build.rs` auto-manages `SCRIPT_SHA` for the pre-commit template; `forge init` Makefile no longer ships a trailing `.` (#46, #47)
- Codex agent `.toml` serialized via the `toml` crate, closing a top-level-table injection (#43)
- `forge provenance` walks all content extensions, not just `.md` (#29 via #38)
- `forge init` deploys hidden template files (`.pre-commit-config.yaml`, `.gitattributes`, `.gitleaks.toml`, `.gitlab-ci.yml`) (#28 via #35)
- Ruff pre-commit hook no longer fires on every commit (#33 via #36)
- Skill `.mdschema` whitelists Claude Code optional frontmatter (`when_to_use`, `argument-hint`, etc.) (#40 via #42)

**Added**
- `forge install` reads a `.forge` consumer manifest, deploying only the artifacts a non-module repo declares (#39 via #50)
- `forge copy` writes SLSA provenance sidecars; `forge drift` consumes them for rename pairing
- `forge install` / `forge deploy` accept repeatable `--provider <NAME>`
- `forge install` / `forge deploy` / `forge clean` default `--source` to `.`

**Changed**
- Codex agent `.toml` adds `name`, `model`, `model_reasoning_effort`; body field renamed `developer_instructions`; `effort` tiers wired through assembly (#43)
- `manifest::generate_statement` uses typed `serde_yaml::to_string` (eliminates YAML injection in interpolated fields)
- POSIX path separators in copy provenance subject names + dependency URIs regardless of host OS
- Source-root check refuses to operate without `module.yaml` (or `.forge`); error names the missing file
- YAML deep-merge type-conflict warning identifies the conflicting key path
- Codex default models refreshed to GPT-5 Codex variants (#41, #51)

**Removed**
- All commands drop their positional path argument; everything is named flags (`--source`, `--target`, `--upstream`)

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` — 465 tests pass
- [x] `target/release/forge --version` reports `forge 0.3.2`
- [ ] After merge, tag `v0.3.2` and push to trigger the release workflow