### PR TITLE
fix: bump module.yaml to 0.3.2 to match v0.3.2 tag

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -1,5 +1,5 @@
 name: forge-cli
-version: 0.3.1
+version: 0.3.2
 type: binary
 description: "Forge module toolkit — assemble, validate, and deploy skills, agents, and rules across AI coding providers."
 events: []


### PR DESCRIPTION
## Summary

- `module.yaml` lagged at `0.3.1` after the v0.3.2 release commit ([#54](https://github.com/N4M3Z/forge-cli/pull/54)) only touched `CHANGELOG.md`. The mismatch breaks downstream consumers whose CI resolves a forge-cli version from `module.yaml` and fails validation against the actual `v0.3.2` tag.

## Test plan

- [x] `module.yaml` reads `version: 0.3.2`
- [x] Matches the `v0.3.2` git tag pointing at `7702832`
- [ ] CI passes on this PR