### PR TITLE
fix: default --target to --source when .forge present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- `forge install` and `forge deploy` default `--target` to `--source` when a `.forge` consumer manifest is present and `--target` is omitted. The consumer dir IS the place the user wants provider trees written; the previous behavior forced redundant `--target .` on every consumer-mode invocation. Module-root flows (no `.forge`) are unchanged: an omitted `--target` still resolves provider directories relative to the current working directory. (#52)
+
 ## [0.3.2] - 2026-05-22
 
 ### Fixed

--- a/src/cli/deploy/mod.rs
+++ b/src/cli/deploy/mod.rs
@@ -48,18 +48,26 @@ pub fn execute(
         Some(module_source_uri)
     };
 
+    // Consumer mode (.forge present): the consumer dir IS the target the user wants
+    // provider trees written into, so an omitted --target defaults to --source.
+    let effective_target: Option<&str> = match target {
+        Some(dir) => Some(dir),
+        None if module_root.join(".forge").is_file() => Some(path),
+        None => None,
+    };
+
     for (provider_name, provider_config) in &providers {
         let build_provider_dir = module_root.join("build").join(provider_name);
         if !build_provider_dir.is_dir() {
             continue;
         }
 
-        let target_base = match target {
+        let target_base = match effective_target {
             Some(dir) => Path::new(dir).join(&provider_config.target),
             None => Path::new(&provider_config.target).to_path_buf(),
         };
 
-        if let Some(dir) = target {
+        if let Some(dir) = effective_target {
             validate_target_boundary(&target_base, Path::new(dir))?;
         }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,7 +49,8 @@ enum Command {
         codex    → <DIR>/.codex\n    \
         gemini   → <DIR>/.gemini\n    \
         opencode → <DIR>/.opencode\n  \
-        Without --target, providers deploy to those paths under the current directory.")]
+        Without --target, providers deploy under the current directory. \
+        In consumer mode (.forge present at --source), --target defaults to --source.")]
     Install {
         /// Module root to install from (must contain module.yaml). Defaults to `.`.
         #[arg(long, value_name = "DIR", default_value = ".")]
@@ -57,6 +58,7 @@ enum Command {
 
         /// Base directory under which each provider gets its own subdirectory.
         /// Without this flag, providers deploy under the current directory.
+        /// In consumer mode (.forge present at --source), this defaults to --source.
         #[arg(long, value_name = "DIR")]
         target: Option<String>,
 
@@ -99,6 +101,7 @@ enum Command {
 
         /// Base directory under which each provider gets its own subdirectory.
         /// Without this flag, providers deploy under the current directory.
+        /// In consumer mode (.forge present at --source), this defaults to --source.
         #[arg(long, value_name = "DIR")]
         target: Option<String>,
 

--- a/tests/dotforge.rs
+++ b/tests/dotforge.rs
@@ -214,6 +214,43 @@ fn dotforge_install_is_idempotent() {
 }
 
 #[test]
+fn dotforge_defaults_target_to_source_when_omitted() {
+    let producer = tempfile::tempdir().unwrap();
+    let consumer = tempfile::tempdir().unwrap();
+    scaffold_producer(producer.path(), "producer");
+    write_skill(producer.path(), "AlphaSkill");
+
+    write_dotforge(
+        consumer.path(),
+        &format!(
+            "version: 1\nsources:\n  producer:\n    path: {p}\nartifacts:\n  producer:\n    skills: [AlphaSkill]\n",
+            p = producer.path().display(),
+        ),
+    );
+
+    // Note: no --target. Issue #52 says deploying should land under the consumer dir.
+    forge()
+        .args(["install", "--source", consumer.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(
+        consumer
+            .path()
+            .join(".claude/skills/AlphaSkill/SKILL.md")
+            .is_file(),
+        "consumer/.claude must receive AlphaSkill when --target is omitted"
+    );
+    assert!(
+        consumer
+            .path()
+            .join(".gemini/skills/AlphaSkill/SKILL.md")
+            .is_file(),
+        "consumer/.gemini must receive AlphaSkill when --target is omitted"
+    );
+}
+
+#[test]
 fn dotforge_errors_on_oversized_file() {
     let consumer = tempfile::tempdir().unwrap();
     // 65 KiB of payload — over the 64 KiB cap enforced in dotforge::load.


### PR DESCRIPTION
Closes #52.

## Problem

In a consumer repo with a `.forge` manifest, `forge install` required spelling out the same path twice: `--source . --target .`. `--source` defaulted to `.`; `--target` had no default.

## Fix

When `.forge` is present at `--source`, `--target` defaults to `--source`. Consumer-mode invocation is now `forge install` with no flags.

## Out of scope

Module-root flows (no `.forge`) are unchanged.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release`: 466 pass (one new)
- [x] `cargo clippy --release -- -D warnings` clean
- [x] New integration test covers the omitted-`--target` path