### PR TITLE
feat: .forge git source resolver (HTTPS-only, SHA-pinned)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- `.forge` consumer manifests accept `git:` sources pinned to a 40-hex commit SHA. `forge install` clones the remote via `gix` into a content-addressed cache at `~/.cache/forge/git/<host>/<owner>/<repo>/`, materializes the pinned tree, and feeds it through the standard assemble + deploy pipeline. HTTPS-only; `ssh://`, `git://`, `git@host:` shorthand, and userinfo URLs are rejected at parse time. Branch names, tags, and abbreviated SHAs are rejected in favor of explicit 40-char commit hashes. Cache hits are instant; the bare clone is reused across SHA pins within the same repository. (#53)
+
 ### Changed
 
 - `forge install` and `forge deploy` default `--target` to `--source` when a `.forge` consumer manifest is present and `--target` is omitted. The consumer dir IS the place the user wants provider trees written; the previous behavior forced redundant `--target .` on every consumer-mode invocation. Module-root flows (no `.forge`) are unchanged: an omitted `--target` still resolves provider directories relative to the current working directory. (#52)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,11 @@ Variant resolution uses qualifier directories (`user/`, `claude/`, `claude-opus-
 
 ### Consumer Manifest (`.forge`)
 
-A non-module project that wants to use forge artifacts drops a `.forge` YAML file at its root listing the requested skills/agents/rules per producer source. `forge install --source <consumer-dir>` reads `.forge`, walks each declared local-path source on disk, filters its content to the requested subset, and runs the standard assemble + deploy pipeline scoped to the consumer's own provider directories. Parser and resolver live at `src/cli/dotforge/` (split into `parse.rs`, `resolve.rs`, `filter.rs`). `assemble::execute` branches on `.forge` presence to choose between `dotforge::resolve_sources` and the existing `sources::collect`. Git-URL sources are reserved for a follow-up issue; this iteration supports local paths only.
+A non-module project that wants to use forge artifacts drops a `.forge` YAML file at its root listing the requested skills/agents/rules per producer source. `forge install --source <consumer-dir>` reads `.forge`, walks each declared source, filters its content to the requested subset, and runs the standard assemble + deploy pipeline scoped to the consumer's own provider directories. Parser, resolver, and git fetcher live at `src/cli/dotforge/` (`parse.rs`, `resolve.rs`, `filter.rs`, `git.rs`). `assemble::execute` branches on `.forge` presence to choose between `dotforge::resolve_sources` and the existing `sources::collect`.
+
+Two source kinds:
+- **Local** (`path: ../forge-core`) — sibling checkout on disk
+- **Git** (`git: https://github.com/N4M3Z/forge-core`, `ref: <40-hex-SHA>`) — remote HTTPS repo pinned to a full commit SHA. Cloned via `gix` into `~/.cache/forge/git/<host>/<owner>/<repo>/` (override with `FORGE_GIT_CACHE_DIR`); the pinned tree is materialized into a per-SHA worktree dir. HTTPS-only, no shorthand or userinfo URLs, no branch / tag refs. `FORGE_GIT_ALLOW_FILE_URLS=1` allows `file://` URLs in tests.
 
 ### Validation
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ chrono = "0.4"
 # utils
 regex = "1"
 console = "0.15"
+dirs = "6"
+
+# git
+gix = { version = "0.66", default-features = false, features = ["blocking-network-client", "blocking-http-transport-reqwest-rust-tls", "worktree-mutation"] }
 
 # optional
 rust-embed = { version = "8", optional = true }

--- a/src/cli/dotforge/git.rs
+++ b/src/cli/dotforge/git.rs
@@ -1,0 +1,200 @@
+//! Fetch git sources declared in `.forge` into a content-addressed cache and
+//! materialize the requested commit's tree into a worktree-shaped directory
+//! that downstream pipeline code treats as a regular module on disk.
+//!
+//! Cache layout:
+//!
+//! ```text
+//! ~/.cache/forge/git/
+//!     <host>/<owner>/<repo>/
+//!         .bare.git/      bare clone, fetched once and reused
+//!         <commit-sha>/   materialized worktree for one pinned SHA
+//! ```
+//!
+//! The bare clone holds all objects ever fetched from the remote. Per-SHA
+//! worktrees are cheap copies of just the tree at that commit, materialized
+//! on demand.
+
+use commands::error::{Error, ErrorKind};
+use std::path::{Path, PathBuf};
+
+pub fn ensure_cached(url: &str, commit: &str, source_label: &str) -> Result<PathBuf, Error> {
+    let cache_root = cache_root()?;
+    let (host, owner, repo) = parse_url(url, source_label)?;
+    let module_root = cache_root.join(&host).join(&owner).join(&repo);
+    let bare_dir = module_root.join(".bare.git");
+    let work_dir = module_root.join(commit);
+
+    if work_dir.join("module.yaml").is_file() {
+        return Ok(work_dir);
+    }
+
+    std::fs::create_dir_all(&module_root).map_err(|error| {
+        Error::new(
+            ErrorKind::Io,
+            format!(
+                "cannot create git cache dir {}: {error}",
+                module_root.display()
+            ),
+        )
+    })?;
+
+    if !bare_dir.exists() {
+        bare_clone(url, &bare_dir, source_label)?;
+    }
+
+    materialize_commit(&bare_dir, commit, &work_dir, source_label)?;
+    Ok(work_dir)
+}
+
+fn cache_root() -> Result<PathBuf, Error> {
+    if let Ok(override_dir) = std::env::var("FORGE_GIT_CACHE_DIR") {
+        return Ok(PathBuf::from(override_dir));
+    }
+    let base = dirs::cache_dir().ok_or_else(|| {
+        Error::new(
+            ErrorKind::Io,
+            "cannot resolve user cache directory (set XDG_CACHE_HOME or HOME)".to_string(),
+        )
+    })?;
+    Ok(base.join("forge").join("git"))
+}
+
+fn parse_url(url: &str, source_label: &str) -> Result<(String, String, String), Error> {
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("file://"))
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::Config,
+                format!(".forge: source '{source_label}' has unsupported URL scheme: {url}"),
+            )
+        })?;
+    let mut parts = after_scheme.trim_start_matches('/').split('/');
+    let host = parts.next().unwrap_or_default().to_string();
+    let owner = parts.next().unwrap_or_default().to_string();
+    let repo_raw = parts.next().unwrap_or_default();
+    let repo = repo_raw.trim_end_matches(".git").to_string();
+    if owner.is_empty() || repo.is_empty() {
+        return Err(Error::new(
+            ErrorKind::Config,
+            format!(
+                ".forge: source '{source_label}' URL must be <scheme>://<host>/<owner>/<repo>, got: {url}"
+            ),
+        ));
+    }
+    let host_safe = if host.is_empty() {
+        "_local".to_string()
+    } else {
+        host
+    };
+    Ok((host_safe, owner, repo))
+}
+
+fn bare_clone(url: &str, bare_dir: &Path, source_label: &str) -> Result<(), Error> {
+    let parsed = gix::Url::try_from(url).map_err(|error| {
+        Error::new(
+            ErrorKind::Config,
+            format!(".forge: source '{source_label}' invalid git URL '{url}': {error}"),
+        )
+    })?;
+    let mut prepare = gix::clone::PrepareFetch::new(
+        parsed,
+        bare_dir,
+        gix::create::Kind::Bare,
+        gix::create::Options::default(),
+        gix::open::Options::isolated(),
+    )
+    .map_err(|error| {
+        Error::new(
+            ErrorKind::Io,
+            format!(".forge: git clone setup for '{source_label}' failed: {error}"),
+        )
+    })?;
+    prepare
+        .fetch_only(gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)
+        .map_err(|error| {
+            Error::new(
+                ErrorKind::Io,
+                format!(".forge: git fetch for '{source_label}' from {url} failed: {error}"),
+            )
+        })?;
+    Ok(())
+}
+
+fn materialize_commit(
+    bare_dir: &Path,
+    commit: &str,
+    work_dir: &Path,
+    source_label: &str,
+) -> Result<(), Error> {
+    let repo = gix::open(bare_dir).map_err(|error| {
+        Error::new(
+            ErrorKind::Io,
+            format!("cannot open git cache at {}: {error}", bare_dir.display()),
+        )
+    })?;
+
+    let oid = gix::ObjectId::from_hex(commit.as_bytes()).map_err(|error| {
+        Error::new(
+            ErrorKind::Config,
+            format!(".forge: source '{source_label}' invalid commit SHA '{commit}': {error}"),
+        )
+    })?;
+
+    let commit_obj = repo.find_object(oid).map_err(|error| {
+        Error::new(
+            ErrorKind::Config,
+            format!(
+                ".forge: source '{source_label}' commit {commit} not found in repository (was it pushed and is it reachable from the default branch?): {error}"
+            ),
+        )
+    })?;
+
+    let tree = commit_obj
+        .peel_to_kind(gix::object::Kind::Tree)
+        .map_err(|error| {
+            Error::new(
+                ErrorKind::Io,
+                format!("cannot resolve tree for commit {commit}: {error}"),
+            )
+        })?;
+
+    std::fs::create_dir_all(work_dir).map_err(|error| {
+        Error::new(
+            ErrorKind::Io,
+            format!("cannot create worktree dir {}: {error}", work_dir.display()),
+        )
+    })?;
+
+    let mut index_file = repo.index_from_tree(&tree.id).map_err(|error| {
+        Error::new(
+            ErrorKind::Io,
+            format!("cannot build index from tree {}: {error}", tree.id),
+        )
+    })?;
+
+    let opts = gix::worktree::state::checkout::Options::default();
+    gix::worktree::state::checkout(
+        &mut index_file,
+        work_dir,
+        repo.objects.clone().into_arc().map_err(|error| {
+            Error::new(ErrorKind::Io, format!("cannot share object store: {error}"))
+        })?,
+        &gix::progress::Discard,
+        &gix::progress::Discard,
+        &gix::interrupt::IS_INTERRUPTED,
+        opts,
+    )
+    .map_err(|error| {
+        Error::new(
+            ErrorKind::Io,
+            format!(
+                "git checkout of {commit} into {} failed: {error}",
+                work_dir.display()
+            ),
+        )
+    })?;
+
+    Ok(())
+}

--- a/src/cli/dotforge/mod.rs
+++ b/src/cli/dotforge/mod.rs
@@ -8,10 +8,14 @@
 //! deploy pipeline scoped to the consumer's own `.claude/`, `.gemini/`,
 //! `.codex/`, `.opencode/` directories.
 //!
-//! Git-URL sources (`Source::Git { ... }`) are reserved for a follow-up
-//! issue; this iteration supports local-path sources only.
+//! Sources can be `Local` (a sibling checkout on disk) or `Git` (a remote
+//! HTTPS repository pinned to a 40-hex commit SHA). Git sources clone via
+//! `gix` into `~/.cache/forge/git/<host>/<owner>/<repo>/`, materialize the
+//! pinned tree into a per-SHA worktree dir, then plug into the regular
+//! pipeline.
 
 mod filter;
+mod git;
 mod parse;
 mod resolve;
 

--- a/src/cli/dotforge/parse.rs
+++ b/src/cli/dotforge/parse.rs
@@ -1,11 +1,18 @@
 //! Schema and parser for `.forge`.
 
 use commands::error::{Error, ErrorKind};
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 pub const SCHEMA_VERSION: u32 = 1;
+
+/// Test-only escape hatch: when this env var is set, `file://` URLs pass
+/// validation so integration tests can use a local bare repo as the origin
+/// without spinning up an HTTPS server. Never set in production: the
+/// HTTPS-only rule defends against `git://` MITM and accidental local-path
+/// pulls that bypass SHA pinning.
+const ALLOW_FILE_URLS_ENV: &str = "FORGE_GIT_ALLOW_FILE_URLS";
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -16,13 +23,104 @@ pub struct DotForge {
     pub artifacts: BTreeMap<String, ArtifactList>,
 }
 
-/// Where to find a producer module on disk. Currently only `Local`; a `Git`
-/// variant is reserved for a follow-up issue. `untagged` so a YAML entry
-/// like `{ path: ../forge-core }` parses without a redundant discriminator.
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields, untagged)]
+/// Where to find a producer module. `Local` for a sibling checkout on disk,
+/// `Git` for a remote HTTPS repository pinned to a 40-hex commit SHA.
+///
+/// A custom `Deserialize` picks the variant by which key is present (`path:`
+/// vs `git:`) so per-variant validation errors propagate cleanly to the
+/// user. `serde(untagged)` would swallow them into a generic "did not match
+/// any variant" message.
+#[derive(Debug)]
 pub enum Source {
     Local { path: PathBuf },
+    Git { git: String, commit: String },
+}
+
+impl<'de> Deserialize<'de> for Source {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+        let value: serde_yaml::Value = Deserialize::deserialize(deserializer)?;
+        let mapping = value.as_mapping().ok_or_else(|| {
+            D::Error::custom(
+                "source entry must be a mapping (e.g. `path: ../foo` or `git: https://...`)",
+            )
+        })?;
+        let has_path = mapping.contains_key(serde_yaml::Value::from("path"));
+        let has_git = mapping.contains_key(serde_yaml::Value::from("git"));
+        match (has_path, has_git) {
+            (true, true) => Err(D::Error::custom(
+                "source entry cannot have both `path` and `git`; pick one",
+            )),
+            (true, false) => {
+                let local: LocalFields = serde_yaml::from_value(value).map_err(D::Error::custom)?;
+                Ok(Source::Local { path: local.path })
+            }
+            (false, true) => {
+                let git: GitFields = serde_yaml::from_value(value).map_err(D::Error::custom)?;
+                validate_git_url(&git.git).map_err(D::Error::custom)?;
+                validate_commit_sha(&git.commit).map_err(D::Error::custom)?;
+                Ok(Source::Git {
+                    git: git.git,
+                    commit: git.commit,
+                })
+            }
+            (false, false) => Err(D::Error::custom(
+                "source entry must contain either `path:` (local checkout) or `git:` (remote URL)",
+            )),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LocalFields {
+    path: PathBuf,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GitFields {
+    git: String,
+    #[serde(rename = "ref")]
+    commit: String,
+}
+
+pub fn validate_git_url(url: &str) -> Result<(), String> {
+    let allow_file = std::env::var(ALLOW_FILE_URLS_ENV).is_ok();
+    if allow_file && url.starts_with("file://") {
+        return Ok(());
+    }
+    let Some(after_scheme) = url.strip_prefix("https://") else {
+        return Err(format!("git URL must start with https://, got: {url}"));
+    };
+    let host_segment = after_scheme.split('/').next().unwrap_or_default();
+    if host_segment.contains('@') {
+        return Err(format!(
+            "git URL must not embed user@ credentials in the host: {url}"
+        ));
+    }
+    if host_segment.is_empty() {
+        return Err(format!("git URL has no host: {url}"));
+    }
+    Ok(())
+}
+
+pub fn validate_commit_sha(sha: &str) -> Result<(), String> {
+    if sha.len() != 40 {
+        return Err(format!(
+            "ref must be a 40-char commit SHA; got {} chars: {sha}",
+            sha.len()
+        ));
+    }
+    if !sha
+        .chars()
+        .all(|character| character.is_ascii_digit() || ('a'..='f').contains(&character))
+    {
+        return Err(format!(
+            "ref must be 40 lowercase hex chars (no branch names, tags, or uppercase): {sha}"
+        ));
+    }
+    Ok(())
 }
 
 /// Per-source list of requested artifact names. Each kind defaults to empty

--- a/src/cli/dotforge/resolve.rs
+++ b/src/cli/dotforge/resolve.rs
@@ -53,13 +53,31 @@ fn canonicalize_source(
     source_label: &str,
     repo_root: &Path,
 ) -> Result<PathBuf, Error> {
-    let Source::Local { path } = source;
+    let materialized = match source {
+        Source::Local { path } => canonicalize_local(path, source_label, repo_root)?,
+        Source::Git { git, commit } => {
+            crate::cli::dotforge::git::ensure_cached(git, commit, source_label)?
+        }
+    };
+    if !materialized.join("module.yaml").is_file() {
+        return Err(Error::new(
+            ErrorKind::Config,
+            format!(
+                ".forge: source '{source_label}' at {} has no module.yaml",
+                materialized.display()
+            ),
+        ));
+    }
+    Ok(materialized)
+}
+
+fn canonicalize_local(path: &Path, source_label: &str, repo_root: &Path) -> Result<PathBuf, Error> {
     let resolved = if path.is_absolute() {
-        path.clone()
+        path.to_path_buf()
     } else {
         repo_root.join(path)
     };
-    let canonical = fs::canonicalize(&resolved).map_err(|error| {
+    fs::canonicalize(&resolved).map_err(|error| {
         Error::new(
             ErrorKind::Config,
             format!(
@@ -67,15 +85,5 @@ fn canonicalize_source(
                 resolved.display()
             ),
         )
-    })?;
-    if !canonical.join("module.yaml").is_file() {
-        return Err(Error::new(
-            ErrorKind::Config,
-            format!(
-                ".forge: source '{source_label}' at {} has no module.yaml",
-                canonical.display()
-            ),
-        ));
-    }
-    Ok(canonical)
+    })
 }

--- a/src/cli/dotforge/tests.rs
+++ b/src/cli/dotforge/tests.rs
@@ -15,7 +15,9 @@ fn parse_minimal_happy_path() {
     let manifest = parse(MINIMAL).expect("minimal manifest must parse");
     assert_eq!(manifest.version, 1);
     assert_eq!(manifest.sources.len(), 1);
-    let Source::Local { path } = &manifest.sources["forge-core"];
+    let Source::Local { path } = &manifest.sources["forge-core"] else {
+        panic!("expected Local source for forge-core");
+    };
     assert_eq!(path.to_string_lossy(), "../forge-core");
     assert_eq!(manifest.artifacts["forge-core"].skills, vec!["BuildSkill"]);
     assert!(manifest.artifacts["forge-core"].agents.is_empty());
@@ -160,6 +162,151 @@ sources:
 ";
     let manifest = parse(content).unwrap();
     assert!(manifest.artifacts.is_empty());
+}
+
+#[test]
+fn parse_accepts_git_source_with_https_url_and_full_sha() {
+    let content = r"
+version: 1
+sources:
+    forge-core:
+        git: https://github.com/N4M3Z/forge-core
+        ref: 0d83a3b9f4e2c1a8b7d6e5f4c3b2a1098765432d
+";
+    let manifest = parse(content).expect("git source manifest must parse");
+    let Source::Git { git, commit } = &manifest.sources["forge-core"] else {
+        panic!("expected Git source for forge-core");
+    };
+    assert_eq!(git, "https://github.com/N4M3Z/forge-core");
+    assert_eq!(commit, "0d83a3b9f4e2c1a8b7d6e5f4c3b2a1098765432d");
+}
+
+#[test]
+fn parse_rejects_git_source_with_http_url() {
+    let content = r"
+version: 1
+sources:
+    bad:
+        git: http://github.com/N4M3Z/forge-core
+        ref: 0d83a3b9f4e2c1a8b7d6e5f4c3b2a1098765432d
+";
+    let error = parse(content).expect_err("http:// must be rejected");
+    assert!(
+        error.to_string().contains("https"),
+        "error must call out the https requirement: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_git_source_with_ssh_shorthand() {
+    let content = r"
+version: 1
+sources:
+    bad:
+        git: git@github.com:N4M3Z/forge-core.git
+        ref: 0d83a3b9f4e2c1a8b7d6e5f4c3b2a1098765432d
+";
+    let error = parse(content).expect_err("git@host: shorthand must be rejected");
+    assert!(
+        error.to_string().contains("https"),
+        "error must call out the https requirement: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_git_source_with_userinfo_in_url() {
+    let content = r"
+version: 1
+sources:
+    bad:
+        git: https://attacker:pass@github.com/N4M3Z/forge-core
+        ref: 0d83a3b9f4e2c1a8b7d6e5f4c3b2a1098765432d
+";
+    let error = parse(content).expect_err("userinfo in URL must be rejected");
+    assert!(
+        error.to_string().to_lowercase().contains("user@"),
+        "error must call out the userinfo ban: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_git_source_with_branch_name_as_ref() {
+    let content = r"
+version: 1
+sources:
+    bad:
+        git: https://github.com/N4M3Z/forge-core
+        ref: main
+";
+    let error = parse(content).expect_err("branch name must be rejected");
+    let message = error.to_string();
+    assert!(
+        message.contains("40-char") || message.contains("commit SHA"),
+        "error must require a full commit SHA: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_git_source_with_short_sha() {
+    let content = r"
+version: 1
+sources:
+    bad:
+        git: https://github.com/N4M3Z/forge-core
+        ref: 0d83a3b9
+";
+    let error = parse(content).expect_err("short SHA must be rejected");
+    assert!(
+        error.to_string().contains("40-char"),
+        "error must require a 40-char SHA: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_git_source_with_uppercase_sha() {
+    let content = r"
+version: 1
+sources:
+    bad:
+        git: https://github.com/N4M3Z/forge-core
+        ref: 0D83A3B9F4E2C1A8B7D6E5F4C3B2A1098765432D
+";
+    let error = parse(content).expect_err("uppercase SHA must be rejected");
+    assert!(
+        error.to_string().contains("lowercase"),
+        "error must require lowercase hex: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_git_source_with_non_hex_sha() {
+    let content = r"
+version: 1
+sources:
+    bad:
+        git: https://github.com/N4M3Z/forge-core
+        ref: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+";
+    let error = parse(content).expect_err("non-hex SHA must be rejected");
+    assert!(
+        error.to_string().contains("hex"),
+        "error must require hex chars: {error}"
+    );
+}
+
+#[test]
+fn parse_rejects_git_source_missing_ref() {
+    let content = r"
+version: 1
+sources:
+    bad:
+        git: https://github.com/N4M3Z/forge-core
+";
+    let error = parse(content).expect_err("git source missing ref must be rejected");
+    assert!(
+        error.to_string().starts_with("Parse:"),
+        "error must be a parse error: {error}"
+    );
 }
 
 #[test]

--- a/tests/dotforge_git.rs
+++ b/tests/dotforge_git.rs
@@ -1,0 +1,220 @@
+//! Integration tests for `.forge` git-source resolution.
+//!
+//! The fixture pattern: create a bare git repo on the local filesystem,
+//! commit a small module into it, then point a consumer `.forge` at the
+//! bare repo via `file://` URL (test-only escape hatch). The runtime uses
+//! gix to clone + materialize the pinned SHA into a tempdir cache, runs
+//! the standard assemble + deploy pipeline, and asserts the artifact
+//! lands in the consumer's provider trees.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+fn forge() -> Command {
+    Command::cargo_bin("forge").unwrap()
+}
+
+fn git(args: &[&str], cwd: &Path) -> std::process::Output {
+    // The test fixtures must never inherit the developer's commit.gpgsign /
+    // tag.gpgsign settings — those trigger YubiKey touch prompts in CI and
+    // serialize parallel tests. -c overrides win over user / system config.
+    let mut full_args: Vec<&str> = vec![
+        "-c",
+        "commit.gpgsign=false",
+        "-c",
+        "tag.gpgsign=false",
+        "-c",
+        "gpg.format=openpgp",
+    ];
+    full_args.extend_from_slice(args);
+    let output = StdCommand::new("git")
+        .args(&full_args)
+        .current_dir(cwd)
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_DIR")
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .output()
+        .expect("git command must run");
+    assert!(
+        output.status.success(),
+        "git {args:?} in {} failed: stdout={} stderr={}",
+        cwd.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    output
+}
+
+fn scaffold_producer_in_workdir(work: &Path) {
+    fs::write(
+        work.join("module.yaml"),
+        "name: producer\nversion: 0.1.0\ndescription: git fixture\nevents: []\nrepository: https://example.com/producer\n",
+    )
+    .unwrap();
+    fs::write(work.join("defaults.yaml"), "").unwrap();
+    let skill_dir = work.join("skills").join("GitSkill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: GitSkill\ndescription: fixture skill in a git repo\nversion: 0.1.0\n---\n\nBody.\n",
+    )
+    .unwrap();
+}
+
+/// Create a bare git repo at `bare_path`, populate it with a module via a
+/// scratch worktree, push, and return the resulting commit SHA.
+fn make_fixture_repo(bare_path: &Path, scratch: &Path) -> String {
+    git(&["init", "--bare", bare_path.to_str().unwrap()], scratch);
+    git(
+        &["init", "--initial-branch=main", scratch.to_str().unwrap()],
+        scratch,
+    );
+    scaffold_producer_in_workdir(scratch);
+    git(&["add", "."], scratch);
+    git(&["commit", "-m", "fixture commit"], scratch);
+    git(
+        &[
+            "remote",
+            "add",
+            "origin",
+            &format!("file://{}", bare_path.display()),
+        ],
+        scratch,
+    );
+    git(&["push", "origin", "main"], scratch);
+    let sha = git(&["rev-parse", "HEAD"], scratch);
+    String::from_utf8(sha.stdout).unwrap().trim().to_string()
+}
+
+#[test]
+fn dotforge_git_source_clones_and_deploys_pinned_sha() {
+    let bare = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    let consumer = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+
+    let bare_path = bare.path().join("producer.git");
+    let sha = make_fixture_repo(&bare_path, scratch.path());
+
+    fs::write(
+        consumer.path().join(".forge"),
+        format!(
+            "version: 1\n\
+             sources:\n  \
+                producer:\n    \
+                    git: file://{bare}\n    \
+                    ref: {sha}\n\
+             artifacts:\n  \
+                producer:\n    \
+                    skills: [GitSkill]\n",
+            bare = bare_path.display(),
+            sha = sha,
+        ),
+    )
+    .unwrap();
+
+    forge()
+        .args(["install", "--source", consumer.path().to_str().unwrap()])
+        .env("FORGE_GIT_ALLOW_FILE_URLS", "1")
+        .env("FORGE_GIT_CACHE_DIR", cache.path())
+        .assert()
+        .success();
+
+    assert!(
+        consumer
+            .path()
+            .join(".claude/skills/GitSkill/SKILL.md")
+            .is_file(),
+        "consumer/.claude must receive GitSkill from the git source"
+    );
+}
+
+#[test]
+fn dotforge_git_source_rejects_uncached_sha_without_match() {
+    let bare = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    let consumer = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+
+    let bare_path = bare.path().join("producer.git");
+    make_fixture_repo(&bare_path, scratch.path());
+
+    let bogus_sha = "0123456789abcdef0123456789abcdef01234567";
+    fs::write(
+        consumer.path().join(".forge"),
+        format!(
+            "version: 1\n\
+             sources:\n  \
+                producer:\n    \
+                    git: file://{bare}\n    \
+                    ref: {bogus_sha}\n\
+             artifacts:\n  \
+                producer:\n    \
+                    skills: [GitSkill]\n",
+            bare = bare_path.display(),
+        ),
+    )
+    .unwrap();
+
+    let output = forge()
+        .args(["install", "--source", consumer.path().to_str().unwrap()])
+        .env("FORGE_GIT_ALLOW_FILE_URLS", "1")
+        .env("FORGE_GIT_CACHE_DIR", cache.path())
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains(bogus_sha) && stderr.to_lowercase().contains("not found"),
+        "error must name the missing SHA and explain not-found: {stderr}"
+    );
+}
+
+#[test]
+fn dotforge_git_source_is_cache_idempotent() {
+    let bare = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    let consumer = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+
+    let bare_path = bare.path().join("producer.git");
+    let sha = make_fixture_repo(&bare_path, scratch.path());
+
+    let manifest = format!(
+        "version: 1\n\
+         sources:\n  \
+            producer:\n    \
+                git: file://{bare}\n    \
+                ref: {sha}\n\
+         artifacts:\n  \
+            producer:\n    \
+                skills: [GitSkill]\n",
+        bare = bare_path.display(),
+    );
+    fs::write(consumer.path().join(".forge"), &manifest).unwrap();
+
+    forge()
+        .args(["install", "--source", consumer.path().to_str().unwrap()])
+        .env("FORGE_GIT_ALLOW_FILE_URLS", "1")
+        .env("FORGE_GIT_CACHE_DIR", cache.path())
+        .assert()
+        .success();
+    let first = fs::read(consumer.path().join(".claude/.manifest")).unwrap();
+
+    forge()
+        .args(["install", "--source", consumer.path().to_str().unwrap()])
+        .env("FORGE_GIT_ALLOW_FILE_URLS", "1")
+        .env("FORGE_GIT_CACHE_DIR", cache.path())
+        .assert()
+        .success();
+    let second = fs::read(consumer.path().join(".claude/.manifest")).unwrap();
+
+    assert_eq!(
+        first, second,
+        ".manifest must be byte-identical across runs"
+    );
+}


### PR DESCRIPTION
Closes #53.

## Problem

`.forge` consumer manifests only support local-path sources (`path: ../forge-core`). Teammates who haven't cloned every producer module locally, CI environments, and reproducible builds all need a way to reference producers by URL.

## Approach

`.forge` now accepts `git:` sources pinned to a 40-hex commit SHA:

```yaml
sources:
    forge-core:
        git: https://github.com/N4M3Z/forge-core
        ref: 0d83a3b9f4e2c1a8b7d6e5f4c3b2a1098765432d
```

Strict parse-time validation: HTTPS-only (no `ssh://`, `git://`, `git@host:`), no userinfo in the URL, no branch names or tags or abbreviated SHAs. Custom `Deserialize` on `Source` picks the variant by key (`path:` vs `git:`) so per-variant validation errors propagate cleanly.

Resolution: gix bare-clones into `~/.cache/forge/git/<host>/<owner>/<repo>/.bare.git/`, materializes the pinned tree into a per-SHA worktree dir via `gix::worktree::state::checkout`, then hands the path to the existing assemble + deploy pipeline. Cache hits skip the clone.

## Out of scope

TOFU trust prompt, `.forge.lock`, hash verification against adopt/v1 sidecars, cache eviction policy.

## Test plan

- [x] `cargo test --release`: 478 pass (9 new parser tests, 3 new git integration tests)
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Integration tests use `file://` URL via `FORGE_GIT_ALLOW_FILE_URLS=1` escape hatch; fixture git repos clear `GIT_WORK_TREE`/`GIT_DIR` to survive prek's pre-commit stash mechanism