### PR TITLE
feat: secret-scan gate fires under jj and git via forge init

### DIFF
--- a/.githooks/jj-push
+++ b/.githooks/jj-push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# forge jj push gate. jj runs no git hooks, so the pre-push gate is relocated here.
+# Wired by `make install` as the repo-local jj `push` alias (absolute path so it
+# resolves from any working directory):
+#   jj config set --repo aliases.push '["util","exec","--","bash","<repo>/.githooks/jj-push"]'
+# Runs the same pre-push gate as git's pre-push hook, then hands off to jj git push.
+# Canonical source: https://github.com/N4M3Z/forge-cli/blob/main/templates/init/.githooks/jj-push
+
+# cd to the repo root so prek finds .pre-commit-config.yaml regardless of cwd.
+cd "$(jj workspace root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || dirname "$0")"
+
+if command -v prek >/dev/null 2>&1; then
+    prek run --all-files --stage pre-push
+elif command -v forge >/dev/null 2>&1; then
+    forge validate
+fi
+
+exec jj git push "$@"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# forge module pre-push hook — runs the pre-push-staged gates (gitleaks, semgrep).
+# Canonical source: https://github.com/N4M3Z/forge-cli/blob/main/templates/init/.githooks/pre-push
+
+SCRIPT_URL="https://raw.githubusercontent.com/N4M3Z/forge-cli/main/scripts/validate.sh"
+SCRIPT_SHA="55998b60a7e972c09c9bcc9767d675b95e011e58309c69849b44fec994909d0b"
+
+if command -v prek >/dev/null 2>&1; then
+    prek run --all-files --stage pre-push
+elif command -v forge >/dev/null 2>&1; then
+    forge validate
+else
+    echo ""
+    echo "  ⚠  Neither prek nor forge found — using validate.sh fallback"
+    echo "     Install: cargo install --locked forge-cli   or   cargo binstall prek"
+    echo ""
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    curl --max-time 30 -sfL "$SCRIPT_URL" -o "$tmpdir/validate.sh" 2>/dev/null \
+        || { echo "validate.sh unreachable — install forge-cli or check connectivity"; exit 1; }
+
+    actual=$(sha256sum "$tmpdir/validate.sh" 2>/dev/null || shasum -a 256 "$tmpdir/validate.sh")
+    actual=${actual%% *}
+
+    if [ "$actual" != "$SCRIPT_SHA" ]; then
+        echo "validate.sh hash mismatch (expected $SCRIPT_SHA, got $actual)"
+        echo "  update SCRIPT_SHA after verifying the new script"
+        exit 1
+    fi
+
+    bash "$tmpdir/validate.sh" .
+fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,6 @@
+[extend]
+useDefault = true
+
 [allowlist]
 paths = [
     "evals/baselines/.*",

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -240,7 +240,7 @@ check_secrets() {
     fi
 
     echo "  gitleaks"
-    if ! gitleaks detect --no-banner --no-git -s . 2>/dev/null; then
+    if ! gitleaks dir --no-banner . 2>/dev/null; then
         ERRORS=$((ERRORS + 1))
     fi
 }

--- a/src/cli/init/tests.rs
+++ b/src/cli/init/tests.rs
@@ -13,6 +13,8 @@ fn init_creates_all_files() {
     assert!(temp_directory.path().join("LICENSE").is_file());
     assert!(temp_directory.path().join("Makefile").is_file());
     assert!(temp_directory.path().join(".githooks/pre-commit").is_file());
+    assert!(temp_directory.path().join(".githooks/pre-push").is_file());
+    assert!(temp_directory.path().join(".githooks/jj-push").is_file());
     assert!(temp_directory.path().join("agents/.mdschema").is_file());
     assert!(temp_directory.path().join("rules/.mdschema").is_file());
 }

--- a/templates/init/.githooks/jj-push
+++ b/templates/init/.githooks/jj-push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# forge jj push gate. jj runs no git hooks, so the pre-push gate is relocated here.
+# Wired by `make install` as the repo-local jj `push` alias (absolute path so it
+# resolves from any working directory):
+#   jj config set --repo aliases.push '["util","exec","--","bash","<repo>/.githooks/jj-push"]'
+# Runs the same pre-push gate as git's pre-push hook, then hands off to jj git push.
+# Canonical source: https://github.com/N4M3Z/forge-cli/blob/main/templates/init/.githooks/jj-push
+
+# cd to the repo root so prek finds .pre-commit-config.yaml regardless of cwd.
+cd "$(jj workspace root 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || dirname "$0")"
+
+if command -v prek >/dev/null 2>&1; then
+    prek run --all-files --stage pre-push
+elif command -v forge >/dev/null 2>&1; then
+    forge validate
+fi
+
+exec jj git push "$@"

--- a/templates/init/.githooks/pre-push
+++ b/templates/init/.githooks/pre-push
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# forge module pre-push hook — runs the pre-push-staged gates (gitleaks, semgrep).
+# Canonical source: https://github.com/N4M3Z/forge-cli/blob/main/templates/init/.githooks/pre-push
+
+SCRIPT_URL="https://raw.githubusercontent.com/N4M3Z/forge-cli/main/scripts/validate.sh"
+SCRIPT_SHA="${VALIDATE_SH_SHA}"
+
+if command -v prek >/dev/null 2>&1; then
+    prek run --all-files --stage pre-push
+elif command -v forge >/dev/null 2>&1; then
+    forge validate
+else
+    echo ""
+    echo "  ⚠  Neither prek nor forge found — using validate.sh fallback"
+    echo "     Install: cargo install --locked forge-cli   or   cargo binstall prek"
+    echo ""
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    curl --max-time 30 -sfL "$SCRIPT_URL" -o "$tmpdir/validate.sh" 2>/dev/null \
+        || { echo "validate.sh unreachable — install forge-cli or check connectivity"; exit 1; }
+
+    actual=$(sha256sum "$tmpdir/validate.sh" 2>/dev/null || shasum -a 256 "$tmpdir/validate.sh")
+    actual=${actual%% *}
+
+    if [ "$actual" != "$SCRIPT_SHA" ]; then
+        echo "validate.sh hash mismatch (expected $SCRIPT_SHA, got $actual)"
+        echo "  update SCRIPT_SHA after verifying the new script"
+        exit 1
+    fi
+
+    bash "$tmpdir/validate.sh" .
+fi

--- a/templates/init/.github/workflows/quality.yaml
+++ b/templates/init/.github/workflows/quality.yaml
@@ -29,8 +29,11 @@ jobs:
 
             - name: Install tools
               run: |
-                  pip install ruff semgrep
+                  pip install ruff semgrep prek
                   sudo apt-get install -y gitleaks
 
-            - name: Validate
+            - name: Validate (commit stage)
               uses: j178/prek-action@v2
+
+            - name: Validate (pre-push stage)
+              run: prek run --all-files --stage pre-push

--- a/templates/init/.gitlab-ci.yml
+++ b/templates/init/.gitlab-ci.yml
@@ -6,6 +6,7 @@ quality:
         - apt-get update && apt-get install -y gitleaks shellcheck
     script:
         - prek run --all-files
+        - prek run --all-files --stage pre-push
     rules:
         - if: $CI_PIPELINE_SOURCE == "merge_request_event"
         - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/templates/init/.gitleaks.toml
+++ b/templates/init/.gitleaks.toml
@@ -1,3 +1,9 @@
+# useDefault is required: a gitleaks config without it REPLACES the built-in
+# ruleset, silently disabling every secret rule. This keeps the defaults and
+# layers the allowlist on top.
+[extend]
+useDefault = true
+
 [allowlist]
 paths = [
     "evals/baselines/.*",

--- a/templates/init/Makefile
+++ b/templates/init/Makefile
@@ -1,20 +1,31 @@
 FORGE ?= forge
 
-.PHONY: help install validate clean
+.PHONY: help install validate validate-push clean
 
 help:
-	@echo "  make install    deploy and activate git hooks"
-	@echo "  make validate   validate module structure and code"
-	@echo "  make clean      remove build artifacts"
+	@echo "  make install        deploy and activate hooks (git + jj)"
+	@echo "  make validate       run commit-stage checks"
+	@echo "  make validate-push  run pre-push checks (gitleaks, semgrep)"
+	@echo "  make clean          remove build artifacts"
 
 install:
 	@command -v $(FORGE) >/dev/null 2>&1 \
 	    || { echo "forge not found — ask an AI assistant to execute INSTALL.md"; exit 1; }
 	git config core.hooksPath .githooks
+	chmod +x .githooks/* 2>/dev/null || true
 	$(FORGE) install
+	@if [ -d .jj ] && command -v jj >/dev/null 2>&1; then \
+	    jj config set --repo aliases.push "[\"util\",\"exec\",\"--\",\"bash\",\"$$PWD/.githooks/jj-push\"]"; \
+	    echo "jj detected: 'jj push' runs the pre-push gate, then 'jj git push'"; \
+	elif [ -d .jj ]; then \
+	    echo "warn: .jj/ present but jj not on PATH — 'jj push' gate NOT wired"; \
+	fi
 
 validate:
 	@bash .githooks/pre-commit
+
+validate-push:
+	@bash .githooks/pre-push
 
 clean:
 	rm -rf build/


### PR DESCRIPTION
The secret gate `forge init` scaffolds was never actually running. jj fires no git hooks, so on a jj-colocated repo the pre-push gitleaks/semgrep stage just sat there. On top of that the gitleaks call had no scan path and the generated `.gitleaks.toml` had no `useDefault`, so it was disabling every rule anyway.

Now init wires a `jj push` alias to `.githooks/jj-push` that runs `prek --stage pre-push` before `jj git push`, mirrors it in `.githooks/pre-push` for git, fixes the gitleaks invocation, sets `useDefault`, and runs the pre-push stage in CI.

`cargo test` covers the new hooks in the init scaffold, and the gitleaks scan of the branch is clean.
