### PR TITLE
fix: template Makefile single validate + real release target

### DIFF
--- a/templates/init/Makefile
+++ b/templates/init/Makefile
@@ -1,31 +1,26 @@
 FORGE ?= forge
 
-.PHONY: help install validate validate-push clean
+.PHONY: help install validate release clean
 
 help:
-	@echo "  make install        deploy and activate hooks (git + jj)"
-	@echo "  make validate       run commit-stage checks"
-	@echo "  make validate-push  run pre-push checks (gitleaks, semgrep)"
-	@echo "  make clean          remove build artifacts"
+	@echo "  make install    deploy content and install the git hooks"
+	@echo "  make validate   run all checks (commit + pre-push stages)"
+	@echo "  make release    build release tarball"
+	@echo "  make clean      remove build artifacts"
 
 install:
 	@command -v $(FORGE) >/dev/null 2>&1 \
 	    || { echo "forge not found — ask an AI assistant to execute INSTALL.md"; exit 1; }
 	git config core.hooksPath .githooks
 	chmod +x .githooks/* 2>/dev/null || true
-	$(FORGE) install
-	@if [ -d .jj ] && command -v jj >/dev/null 2>&1; then \
-	    jj config set --repo aliases.push "[\"util\",\"exec\",\"--\",\"bash\",\"$$PWD/.githooks/jj-push\"]"; \
-	    echo "jj detected: 'jj push' runs the pre-push gate, then 'jj git push'"; \
-	elif [ -d .jj ]; then \
-	    echo "warn: .jj/ present but jj not on PATH — 'jj push' gate NOT wired"; \
-	fi
+	$(FORGE) install --target ~
 
 validate:
 	@bash .githooks/pre-commit
-
-validate-push:
 	@bash .githooks/pre-push
+
+release:
+	$(FORGE) release
 
 clean:
 	rm -rf build/


### PR DESCRIPTION
Brings the `forge init` template Makefile to the standard: one `make validate` that runs both the commit and pre-push stages (so it can't pass while skipping the secret scan), a real `release` target, and `forge install --target ~`.

`make install` does content + git hooks; the jj `push` gate is global jj config, not the Makefile.
