### PR TITLE
fix: stage gitleaks at pre-push so the push hooks scan it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
             entry: gitleaks detect --no-banner
             language: system
             pass_filenames: false
+            stages: [pre-push]
 
           - id: semgrep
             name: semgrep OWASP


### PR DESCRIPTION
## Problem
The `jj-push` and `pre-push` hooks run `prek run --all-files --stage pre-push`, but gitleaks was registered at the commit stage with no `stages:` key. Under jj (which runs no commit hooks) the push gate therefore never ran gitleaks — the hook fired but scanned nothing.

## Fix
Stage gitleaks at `pre-push`, matching the module standard. Commit-time scanning is unaffected (`forge-validate` runs gitleaks internally at the commit stage).

## Test plan
- [x] `quality` / `build` pass on this PR