### PR TITLE
feat: forge watch registry for monitored locations

### DIFF
--- a/docs/decisions/CLI-0011 Watchlist Monitored-Source Registry.md
+++ b/docs/decisions/CLI-0011 Watchlist Monitored-Source Registry.md
@@ -1,0 +1,53 @@
+---
+title: "Watchlist Monitored-Source Registry"
+description: "forge watch maintains a user-curated registry of module and deployment locations to monitor, as local paths or SHA-pinned remotes"
+type: adr
+category: cli
+tags:
+    - cli
+    - watch
+status: accepted
+created: 2026-06-04
+updated: 2026-06-23
+author: "@N4M3Z"
+project: forge-cli
+related: []
+responsible: ["@N4M3Z"]
+accountable: ["@N4M3Z"]
+consulted: []
+informed: []
+upstream: []
+---
+
+# Watchlist Monitored-Source Registry
+
+## Context and Problem Statement
+
+forge acts on the module or deployment at the current directory. A developer usually has other locations they care about too: module sources elsewhere on disk, downstream repos that adopt forge artifacts, or a remote repo pinned to a known commit. forge has no way to keep track of those: no registry of locations to watch, and no way to watch a remote at all. Everything is implicit in wherever a command happens to run.
+
+## Decision Drivers
+
+- An explicit, user-controlled list of locations forge should keep track of, beyond the working directory and home
+- The ability to watch a remote repo at a pinned commit, not only local paths
+- Reuse of the existing `.forge` security and fetch model rather than a second clone path
+
+## Considered Options
+
+1. **Auto-discover sibling directories.** Zero-config, but implicit: it misses repos elsewhere on disk and gives the user no way to say what they actually want watched.
+2. **An explicit `forge watch` registry.** A file the user curates, listing exactly the locations to monitor, local or remote.
+
+## Decision Outcome
+
+`forge watch` maintains a registry at `~/.config/forge/watchlist.yaml`: a `locations` list managed by `forge watch list` / `add` / `git` / `remove`.
+
+An entry is either a local path string or a SHA-pinned remote `{ git: <https-url>, ref: <40-hex-sha> }`, the same shape `.forge` uses. Remotes go through the same validators (HTTPS-only, lowercase 40-hex SHA, no embedded credentials) and the same content-addressed cache fetcher, then resolve to a local worktree like any other path; a fetch failure logs and skips that entry. The file is plain YAML and backward compatible, so a bare list of path strings still parses. Mutations load it strictly: a malformed or unknown-key file is reported and left untouched rather than overwritten.
+
+## Consequences
+
+- The watched set is explicit and user-curated; there is no implicit discovery to reason about.
+- Remote watching reuses `.forge`'s validators and cache, so HTTPS and SHA-pinning live in one code path, not two.
+- An entry records only its location. Storing anything more per entry later is a schema addition.
+
+## More Information
+
+- `forge watch git` and `.forge` git sources share the same validators and fetch path (`src/cli/dotforge/`).

--- a/src/cli/dotforge/mod.rs
+++ b/src/cli/dotforge/mod.rs
@@ -26,7 +26,8 @@ use commands::error::{Error, ErrorKind};
 use std::fs;
 use std::path::Path;
 
-pub use parse::DotForge;
+pub use git::ensure_cached;
+pub use parse::{DotForge, validate_commit_sha, validate_git_url};
 pub use resolve::resolve_sources;
 
 const MAX_BYTES: usize = 64 * 1024;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,11 +10,14 @@ mod output;
 mod provenance;
 mod release;
 mod validate;
+mod watchlist;
 
 #[cfg(test)]
 mod tests;
 
 use clap::{Parser, Subcommand};
+use commands::error::Error;
+use commands::result::ActionResult;
 
 #[derive(Parser)]
 #[command(name = "forge", about = "Forge module toolkit", version)]
@@ -203,6 +206,36 @@ enum Command {
         #[arg(long)]
         embed: bool,
     },
+
+    /// Manage the watchlist of module and deployment locations to monitor
+    Watch {
+        #[command(subcommand)]
+        action: WatchAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum WatchAction {
+    /// List watched locations
+    List,
+    /// Add a local path to the watchlist
+    Add {
+        /// Path to a module or deployment target (supports a leading `~/`).
+        path: String,
+    },
+    /// Watch a remote repo pinned to a commit SHA
+    Git {
+        /// HTTPS URL of the repo to monitor.
+        url: String,
+        /// Full 40-char lowercase-hex commit SHA to pin.
+        #[arg(long = "ref")]
+        reference: String,
+    },
+    /// Remove a watched entry by its path or git URL
+    Remove {
+        /// Path or git URL to stop watching.
+        path: String,
+    },
 }
 
 /// Parse CLI arguments, dispatch to subcommand, and return an exit code.
@@ -265,42 +298,57 @@ pub fn run() -> i32 {
             source_uri,
             show_orphans,
         } => {
-            return match provenance::execute(
+            return exit_code(provenance::execute(
                 &target,
                 source_uri.as_deref(),
                 show_orphans,
                 args.json,
-            ) {
-                Ok(code) => code,
-                Err(error) => {
-                    eprintln!("fatal: {error}");
-                    2
-                }
-            };
+            ));
         }
         Command::Drift {
             source,
             upstream,
             ignore,
-        } => {
-            return match drift::execute(&source, &upstream, &ignore, args.json) {
-                Ok(code) => code,
-                Err(error) => {
-                    eprintln!("fatal: {error}");
-                    2
-                }
-            };
-        }
+        } => return exit_code(drift::execute(&source, &upstream, &ignore, args.json)),
         Command::Clean { source, target } => (
             deploy::execute(&source, target.as_deref(), &[], false, true, false, false),
             "cleaned",
         ),
         Command::Release { source, embed } => (release::execute(&source, embed), "released"),
+        Command::Watch { action } => return run_watch(action, args.json),
     };
 
+    report(result, args.json, verb)
+}
+
+/// Collapse a subcommand's `Result<exit_code, _>` into a process exit code,
+/// printing a `fatal:` line on `Err`.
+fn exit_code<E: std::fmt::Display>(result: Result<i32, E>) -> i32 {
+    match result {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("fatal: {error}");
+            2
+        }
+    }
+}
+
+/// Dispatch a `forge watch` subcommand to its handler.
+fn run_watch(action: WatchAction, json: bool) -> i32 {
+    let result = match action {
+        WatchAction::List => watchlist::list(json),
+        WatchAction::Add { path } => watchlist::add_path(&path, json),
+        WatchAction::Git { url, reference } => watchlist::add_git(&url, &reference, json),
+        WatchAction::Remove { path } => watchlist::remove(&path, json),
+    };
+    exit_code(result)
+}
+
+/// Print a structured `ActionResult` and return the corresponding exit code.
+fn report(result: Result<ActionResult, Error>, json: bool, verb: &str) -> i32 {
     match result {
         Ok(action_result) => {
-            output::print(&action_result, args.json, verb);
+            output::print(&action_result, json, verb);
             i32::from(action_result.has_errors())
         }
         Err(error) => {

--- a/src/cli/watchlist/mod.rs
+++ b/src/cli/watchlist/mod.rs
@@ -1,0 +1,264 @@
+//! `forge watch` manages the registry of module/deployment locations to
+//! monitor, beyond `~` and the cwd. Stored at
+//! `~/.config/forge/watchlist.yaml`. Each entry is either a local path string
+//! or a SHA-pinned remote `{ git: <https-url>, ref: <40-hex-sha> }`, the same
+//! shape `.forge` uses; remote entries are cloned into the shared git cache and
+//! resolved like any local module.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+enum WatchEntry {
+    Git {
+        git: String,
+        #[serde(rename = "ref")]
+        reference: String,
+    },
+    Path(String),
+}
+
+impl WatchEntry {
+    fn sort_key(&self) -> String {
+        match self {
+            WatchEntry::Path(path) => path.clone(),
+            WatchEntry::Git { git, reference } => format!("{git}#{reference}"),
+        }
+    }
+
+    fn label(&self) -> String {
+        match self {
+            WatchEntry::Path(path) => path.clone(),
+            WatchEntry::Git { git, reference } => format!("{git}@{reference}"),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct WatchlistConfig {
+    #[serde(default)]
+    locations: Vec<WatchEntry>,
+}
+
+fn config_path() -> Result<PathBuf, String> {
+    dirs::home_dir()
+        .map(|home| home.join(".config/forge/watchlist.yaml"))
+        .ok_or_else(|| "cannot resolve home directory".to_string())
+}
+
+/// Reads the watchlist tolerantly: a missing, unreadable, or malformed file
+/// yields an empty config (with a warning). For read-only callers (`list` and
+/// other monitors) where one bad file must never abort the read.
+fn load_lenient_from(path: &Path) -> WatchlistConfig {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return WatchlistConfig::default();
+        }
+        Err(error) => {
+            eprintln!(
+                "warning: cannot read {} ({error}), treating watchlist as empty",
+                path.display()
+            );
+            return WatchlistConfig::default();
+        }
+    };
+    match serde_yaml::from_str(&content) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!(
+                "warning: {} is malformed ({error}), treating watchlist as empty",
+                path.display()
+            );
+            WatchlistConfig::default()
+        }
+    }
+}
+
+/// Reads the watchlist strictly: a missing file is an empty config (so the
+/// first `add` still succeeds), but an unreadable or malformed file is an
+/// error. For mutating callers, so a corrupt file is never silently
+/// overwritten and its existing entries lost.
+fn load_strict_from(path: &Path) -> Result<WatchlistConfig, String> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(WatchlistConfig::default());
+        }
+        Err(error) => return Err(format!("cannot read {}: {error}", path.display())),
+    };
+    serde_yaml::from_str(&content).map_err(|error| {
+        format!(
+            "{} is malformed ({error}); refusing to overwrite. Fix or remove the file, then retry.",
+            path.display()
+        )
+    })
+}
+
+fn load_lenient() -> WatchlistConfig {
+    match config_path() {
+        Ok(path) => load_lenient_from(&path),
+        Err(error) => {
+            eprintln!("warning: {error}, treating watchlist as empty");
+            WatchlistConfig::default()
+        }
+    }
+}
+
+fn load_strict() -> Result<WatchlistConfig, String> {
+    load_strict_from(&config_path()?)
+}
+
+fn save(config: &WatchlistConfig) -> Result<(), String> {
+    let path = config_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("cannot create {}: {error}", parent.display()))?;
+    }
+    let yaml = serde_yaml::to_string(config).map_err(|error| format!("serialize: {error}"))?;
+    fs::write(&path, yaml).map_err(|error| format!("cannot write {}: {error}", path.display()))
+}
+
+fn announce(json: bool, message: &str) {
+    if json {
+        println!("{}", serde_json::json!({ "message": message }));
+    } else {
+        println!("{message}");
+    }
+}
+
+fn sort_and_save(config: &mut WatchlistConfig) -> Result<(), String> {
+    config.locations.sort_by_key(WatchEntry::sort_key);
+    save(config)
+}
+
+/// Lists watched locations.
+#[allow(clippy::unnecessary_wraps)]
+pub fn list(json: bool) -> Result<i32, String> {
+    print_locations(&load_lenient().locations, json);
+    Ok(0)
+}
+
+/// Adds a local path to the watchlist.
+pub fn add_path(path: &str, json: bool) -> Result<i32, String> {
+    let mut config = load_strict()?;
+    if config
+        .locations
+        .iter()
+        .any(|entry| matches!(entry, WatchEntry::Path(existing) if existing == path))
+    {
+        announce(json, &format!("already watched: {path}"));
+        return Ok(0);
+    }
+    config.locations.push(WatchEntry::Path(path.to_string()));
+    sort_and_save(&mut config)?;
+    announce(json, &format!("watching: {path}"));
+    Ok(0)
+}
+
+/// Adds a SHA-pinned remote repo. HTTPS-only, full 40-char lowercase-hex commit required.
+pub fn add_git(url: &str, reference: &str, json: bool) -> Result<i32, String> {
+    super::dotforge::validate_git_url(url)?;
+    super::dotforge::validate_commit_sha(reference)?;
+    let mut config = load_strict()?;
+    if config.locations.iter().any(|entry| {
+        matches!(entry, WatchEntry::Git { git, reference: pinned } if git == url && pinned == reference)
+    }) {
+        announce(json, &format!("already watched: {url}@{reference}"));
+        return Ok(0);
+    }
+    config.locations.push(WatchEntry::Git {
+        git: url.to_string(),
+        reference: reference.to_string(),
+    });
+    sort_and_save(&mut config)?;
+    announce(json, &format!("watching: {url}@{reference}"));
+    Ok(0)
+}
+
+/// Removes a watched entry by its path or git URL.
+pub fn remove(target: &str, json: bool) -> Result<i32, String> {
+    let mut config = load_strict()?;
+    let before = config.locations.len();
+    config.locations.retain(|entry| match entry {
+        WatchEntry::Path(path) => path != target,
+        WatchEntry::Git { git, .. } => git != target,
+    });
+    if config.locations.len() == before {
+        return Err(format!("not watched: {target}"));
+    }
+    save(&config)?;
+    announce(json, &format!("removed: {target}"));
+    Ok(0)
+}
+
+fn print_locations(locations: &[WatchEntry], json: bool) {
+    if json {
+        let labels: Vec<String> = locations.iter().map(WatchEntry::label).collect();
+        println!("{}", serde_json::json!({ "locations": labels }));
+        return;
+    }
+    if locations.is_empty() {
+        println!("No watched locations. Add one with: forge watch add <path>");
+        return;
+    }
+    for entry in locations {
+        match entry {
+            WatchEntry::Path(path) => {
+                let marker = if resolve(path).is_some_and(|resolved| resolved.exists()) {
+                    "ok"
+                } else {
+                    "missing"
+                };
+                println!("{path}  [{marker}]");
+            }
+            WatchEntry::Git { git, reference } => {
+                println!("{git} @ {reference}  [git]");
+            }
+        }
+    }
+}
+
+/// Expands a leading `~/` and returns the resolved path.
+fn resolve(location: &str) -> Option<PathBuf> {
+    if let Some(rest) = location.strip_prefix("~/") {
+        return dirs::home_dir().map(|home| home.join(rest));
+    }
+    Some(PathBuf::from(location))
+}
+
+/// Reads the watched locations (expanded), for tools that monitor them. Remote
+/// git entries are cloned into the shared cache and their pinned worktree
+/// returned; a fetch failure is logged and that entry skipped.
+#[must_use]
+#[allow(dead_code)]
+pub fn watched_locations() -> Vec<PathBuf> {
+    load_lenient()
+        .locations
+        .iter()
+        .filter_map(resolve_entry)
+        .collect()
+}
+
+#[allow(dead_code)]
+fn resolve_entry(entry: &WatchEntry) -> Option<PathBuf> {
+    match entry {
+        WatchEntry::Path(path) => resolve(path),
+        WatchEntry::Git { git, reference } => {
+            match super::dotforge::ensure_cached(git, reference, git) {
+                Ok(worktree) => Some(worktree),
+                Err(error) => {
+                    eprintln!("warning: watch git {git}@{reference}: {error}");
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/cli/watchlist/tests.rs
+++ b/src/cli/watchlist/tests.rs
@@ -1,0 +1,185 @@
+use super::*;
+
+#[test]
+fn resolve_passes_through_absolute_paths() {
+    assert_eq!(resolve("/abs/path"), Some(PathBuf::from("/abs/path")));
+}
+
+#[test]
+fn resolve_expands_leading_tilde() {
+    let home = dirs::home_dir().expect("home dir for test");
+    assert_eq!(resolve("~/forge"), Some(home.join("forge")));
+}
+
+#[test]
+fn parses_path_locations_from_yaml() {
+    let config: WatchlistConfig =
+        serde_yaml::from_str("locations:\n    - /a\n    - /b\n").expect("parse yaml");
+    assert_eq!(
+        config.locations,
+        vec![
+            WatchEntry::Path("/a".to_string()),
+            WatchEntry::Path("/b".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn parses_mixed_path_and_git_entries() {
+    let yaml = "locations:\n    - /local/repo\n    - git: https://github.com/N4M3Z/forge-core\n      ref: 0123456789abcdef0123456789abcdef01234567\n";
+    let config: WatchlistConfig = serde_yaml::from_str(yaml).expect("parse mixed yaml");
+    assert_eq!(
+        config.locations,
+        vec![
+            WatchEntry::Path("/local/repo".to_string()),
+            WatchEntry::Git {
+                git: "https://github.com/N4M3Z/forge-core".to_string(),
+                reference: "0123456789abcdef0123456789abcdef01234567".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn git_entry_round_trips_through_yaml() {
+    let entry = WatchEntry::Git {
+        git: "https://github.com/N4M3Z/forge-core".to_string(),
+        reference: "0123456789abcdef0123456789abcdef01234567".to_string(),
+    };
+    let config = WatchlistConfig {
+        locations: vec![entry.clone()],
+    };
+    let yaml = serde_yaml::to_string(&config).expect("serialize");
+    let parsed: WatchlistConfig = serde_yaml::from_str(&yaml).expect("reparse");
+    assert_eq!(parsed.locations, vec![entry]);
+}
+
+#[test]
+fn empty_yaml_yields_no_locations() {
+    let config: WatchlistConfig = serde_yaml::from_str("{}").expect("parse empty");
+    assert!(config.locations.is_empty());
+}
+
+#[test]
+fn add_git_rejects_non_https_url() {
+    let error = add_git("git@github.com:N4M3Z/forge-core.git", "0123", false)
+        .expect_err("ssh url must be rejected");
+    assert!(error.contains("https://"));
+}
+
+#[test]
+fn add_git_rejects_short_sha() {
+    let error = add_git("https://github.com/N4M3Z/forge-core", "abc123", false)
+        .expect_err("short sha must be rejected");
+    assert!(error.contains("40-char"), "got: {error}");
+}
+
+#[test]
+fn add_git_rejects_non_hex_sha() {
+    let bad = "z123456789abcdef0123456789abcdef01234567";
+    let error = add_git("https://github.com/N4M3Z/forge-core", bad, false)
+        .expect_err("non-hex sha must be rejected");
+    assert!(error.contains("hex"), "got: {error}");
+}
+
+#[test]
+fn add_git_rejects_uppercase_sha() {
+    let upper = "0123456789ABCDEF0123456789ABCDEF01234567";
+    let error = add_git("https://github.com/N4M3Z/forge-core", upper, false)
+        .expect_err("uppercase sha must be rejected");
+    assert!(error.contains("hex"), "got: {error}");
+}
+
+#[test]
+fn add_git_rejects_userinfo_in_host() {
+    let valid_sha = "0123456789abcdef0123456789abcdef01234567";
+    let error = add_git("https://user@github.com/N4M3Z/forge-core", valid_sha, false)
+        .expect_err("user@ in host must be rejected");
+    assert!(error.contains("user@"), "got: {error}");
+}
+
+#[test]
+fn add_git_rejects_empty_host() {
+    let valid_sha = "0123456789abcdef0123456789abcdef01234567";
+    let error = add_git("https:///N4M3Z/forge-core", valid_sha, false)
+        .expect_err("empty host must be rejected");
+    assert!(error.contains("no host"), "got: {error}");
+}
+
+#[test]
+fn load_strict_from_absent_path_is_empty_ok() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("watchlist.yaml");
+    let config = load_strict_from(&path).expect("absent file is ok");
+    assert!(config.locations.is_empty());
+}
+
+#[test]
+fn load_strict_from_zero_byte_file_is_empty_ok() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("watchlist.yaml");
+    std::fs::write(&path, "").expect("write empty");
+    let config = load_strict_from(&path).expect("empty file is ok");
+    assert!(config.locations.is_empty());
+}
+
+#[test]
+fn load_strict_from_valid_file_returns_locations() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("watchlist.yaml");
+    std::fs::write(&path, "locations:\n    - /a\n    - /b\n").expect("write valid");
+    let config = load_strict_from(&path).expect("valid file parses");
+    assert_eq!(
+        config.locations,
+        vec![
+            WatchEntry::Path("/a".to_string()),
+            WatchEntry::Path("/b".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn load_strict_from_corrupt_file_errs_without_touching_bytes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("watchlist.yaml");
+    let corrupt = "locations:\n    - [unterminated\n";
+    std::fs::write(&path, corrupt).expect("write corrupt");
+    let error = load_strict_from(&path).expect_err("corrupt file must error");
+    assert!(error.contains("malformed"), "got: {error}");
+    let after = std::fs::read_to_string(&path).expect("reread");
+    assert_eq!(after, corrupt, "corrupt file must be left untouched");
+}
+
+#[test]
+fn load_strict_from_unknown_key_errs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("watchlist.yaml");
+    std::fs::write(&path, "version: 1\nlocations: []\n").expect("write unknown key");
+    let error = load_strict_from(&path).expect_err("unknown key must error");
+    assert!(error.contains("malformed"), "got: {error}");
+}
+
+#[test]
+fn load_lenient_from_corrupt_file_is_empty() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("watchlist.yaml");
+    std::fs::write(&path, "locations:\n    - [unterminated\n").expect("write corrupt");
+    let config = load_lenient_from(&path);
+    assert!(config.locations.is_empty());
+}
+
+#[test]
+fn json_label_with_backslash_and_newline_round_trips() {
+    let label = WatchEntry::Path("a\\b\nc".to_string()).label();
+    let value = serde_json::json!({ "locations": [label] });
+    let parsed: serde_json::Value = serde_json::from_str(&value.to_string()).expect("valid JSON");
+    assert_eq!(parsed["locations"][0], "a\\b\nc");
+}
+
+#[test]
+fn json_announce_message_with_quote_and_newline_is_valid() {
+    let message = "say \"hi\"\nthen bye";
+    let value = serde_json::json!({ "message": message });
+    let parsed: serde_json::Value = serde_json::from_str(&value.to_string()).expect("valid JSON");
+    assert_eq!(parsed["message"], "say \"hi\"\nthen bye");
+}


### PR DESCRIPTION
forge has no place to declare the module and deployment locations it should keep track of beyond the current directory and `~`, and no way to watch a remote repo at all. There is only whatever happens to sit where a command runs.

`forge watch` maintains a registry at `~/.config/forge/watchlist.yaml`:

- `forge watch list`: show watched locations with status (ok / missing)
- `forge watch add <path>`: register a local module or deployment target (a leading `~/` expands)
- `forge watch git <url> --ref <sha>`: register a remote HTTPS repo pinned to a 40-char commit SHA
- `forge watch remove <path-or-url>`: drop an entry

A remote entry reuses `.forge`'s model end to end: the same `{ git, ref }` shape, the same validators (HTTPS-only, lowercase 40-hex SHA, no embedded credentials), and the same content-addressed cache fetcher. The file is plain YAML (a bare list of path strings still parses), and a mutation against a malformed or unknown-key file is reported and left untouched, never silently overwritten.

## Test plan

- [x] `cargo test`: watchlist unit tests (validator rejection, strict/lenient load, JSON round-trip)
- [x] `cargo clippy -- -D warnings` and `cargo fmt --check` clean
- [x] `forge watch add` / `list` / `remove` against real paths
