### PR TITLE
fix: agents-to-toml converts only agents, not skills or rules

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,7 +13,7 @@ The core philosophy is "Author Once, Deploy Everywhere." Authors write provider-
 - **Variant Resolution:** Supports overrides via `user/`, `provider/`, and `model/` subdirectories with a clear precedence order (`user/` > `provider/model/` > `provider/` > root).
 - **Provenance & Manifests:** Generates SLSA/in-toto sidecars and `.manifest` files to track source-to-deployed chains and detect local modifications.
 - **Validation:** Enforces module structure and `.mdschema` compliance for agents and documents.
-- **Provider-Specific Transforms:** Handles `kebab-case` filenames, tool name remapping, and TOML conversion (for Codex).
+- **Provider-Specific Transforms:** Handles `kebab-case` filenames, tool name remapping, and TOML conversion (Codex agents only; skills and rules stay markdown).
 
 ### Technologies
 - **Language:** Rust (2024 edition)

--- a/docs/decisions/ASSEMBLY-0001 Content Assembly Pipeline.md
+++ b/docs/decisions/ASSEMBLY-0001 Content Assembly Pipeline.md
@@ -49,7 +49,7 @@ Steps:
 2. **Resolve variant** — check qualifier directories (user/ > provider/model/ > provider/ > base) for overrides
 3. **Merge** — combine base + variant body using the variant's `mode` field (append, prepend, replace)
 4. **Strip** — remove frontmatter delimiters, H1 heading, and reference-style link definitions from the assembled body
-5. **Format** — apply provider-specific output formatting (YAML frontmatter for Claude/Gemini/OpenCode, TOML for Codex)
+5. **Format** — apply provider-specific output formatting (YAML frontmatter for Claude/Gemini/OpenCode; TOML for Codex agents only, while Codex skills and rules stay markdown)
 
 ## Consequences
 

--- a/docs/decisions/ASSEMBLY-0004 Assembly and Deployment Pipeline.md
+++ b/docs/decisions/ASSEMBLY-0004 Assembly and Deployment Pipeline.md
@@ -60,7 +60,7 @@ Transforms source content into provider-specific output:
 3. Merge — combine base + variant body using variant's `mode` (append, prepend, replace)
 4. Strip frontmatter — remove `---` delimiters, H1 heading from body
 5. Strip reference links — remove `[N]: url` definitions and `[N]` inline markers
-6. Format per provider — YAML frontmatter (Claude/Gemini/OpenCode), TOML (Codex), kebab-case names (Gemini/OpenCode), tool remapping (Gemini)
+6. Format per provider — YAML frontmatter (Claude/Gemini/OpenCode), TOML for Codex agents only (skills and rules stay markdown), kebab-case names (Gemini/OpenCode), tool remapping (Gemini)
 7. Write sidecar — `.yaml` companion preserving stripped frontmatter + provenance
 
 Output structure:

--- a/docs/decisions/ASSEMBLY-0007 Cross-Provider Convergence.md
+++ b/docs/decisions/ASSEMBLY-0007 Cross-Provider Convergence.md
@@ -31,8 +31,8 @@ This convergence changes what forge-cli needs to do over time.
 
 ## Decision Drivers
 
-- `.agents/skills/SKILL.md` is becoming the universal format
-- Provider-specific formatting (TOML for Codex, kebab-case for Gemini) is transitional
+- `.agents/skills/SKILL.md` is the universal skill format; forge deploys skills as `SKILL.md` for every provider, Codex included
+- Provider-specific formatting (TOML for Codex agents, kebab-case for Gemini) is transitional and applies to agents only, never skills or rules
 - forge-cli's deployment layer should shrink as providers converge
 - Assembly and validation are the durable capabilities
 
@@ -56,7 +56,7 @@ Design the forge tool as an **assembler and validator** whose deployment layer i
 
 - Per-provider directory routing (`.claude/`, `.gemini/`, `.codex/`, `.opencode/`), probably
 - Name format conversion (PascalCase → kebab-case)
-- Body format conversion (markdown → TOML)
+- Body format conversion (markdown → TOML), agents only
 - Tool name remapping (Read → read_file)
 
 ### Timeline expectation

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -15,9 +15,10 @@ use crate::provider::AssemblyRule;
 /// Returns the transformed `(content, filename)` pair.
 ///
 /// Rules are applied sequentially:
-///   - `KebabCase` — transforms filename from `PascalCase` to kebab-case (only for agents)
+///   - `KebabCase` — transforms filename from `PascalCase` to kebab-case
 ///   - `RemapTools` — replaces tool names in backtick spans
-///   - `AgentsToToml` — converts markdown body to TOML, changes `.md` to `.toml`
+///   - `AgentsToToml` — converts an agent's markdown to TOML and `.md` to `.toml`;
+///     agents only, so skills (Codex reads `SKILL.md`) and rules stay markdown
 pub fn apply_rules(
     content: &str,
     filename: &str,
@@ -50,9 +51,11 @@ pub fn apply_rules(
                 current_content = remap_tools(&current_content, tool_mappings);
             }
             AssemblyRule::AgentsToToml => {
-                current_content = markdown_to_toml(&current_filename, &current_content)?;
-                let (stem, _) = split_extension(&current_filename);
-                current_filename = format!("{stem}.toml");
+                if kind == "agents" {
+                    current_content = markdown_to_toml(&current_filename, &current_content)?;
+                    let (stem, _) = split_extension(&current_filename);
+                    current_filename = format!("{stem}.toml");
+                }
             }
             AssemblyRule::StripLinks => {}
         }

--- a/src/transform/tests.rs
+++ b/src/transform/tests.rs
@@ -322,6 +322,43 @@ fn apply_rules_kebab_case_agents_skips_filename_for_rules() {
 }
 
 #[test]
+fn apply_rules_agents_to_toml_converts_agents() {
+    let rules = vec![AssemblyRule::AgentsToToml];
+    let mappings = HashMap::new();
+    let content = "---\nname: TestAgent\ndescription: Test agent\n---\n\nBody.";
+
+    let (out, filename) =
+        apply_rules(content, "TestAgent.md", &rules, &mappings, "agents").unwrap();
+
+    assert_eq!(filename, "TestAgent.toml");
+    assert!(out.contains("description = \"Test agent\""));
+}
+
+#[test]
+fn apply_rules_agents_to_toml_leaves_skills_as_markdown() {
+    let rules = vec![AssemblyRule::AgentsToToml];
+    let mappings = HashMap::new();
+    let content = "---\nname: WebDevelopment\ndescription: Web skill\n---\n\nBody.";
+
+    let (out, filename) = apply_rules(content, "SKILL.md", &rules, &mappings, "skills").unwrap();
+
+    assert_eq!(filename, "SKILL.md");
+    assert_eq!(out, content);
+}
+
+#[test]
+fn apply_rules_agents_to_toml_leaves_rules_as_markdown() {
+    let rules = vec![AssemblyRule::AgentsToToml];
+    let mappings = HashMap::new();
+    let content = "---\nname: NoEmDash\n---\n\nBody.";
+
+    let (out, filename) = apply_rules(content, "NoEmDash.md", &rules, &mappings, "rules").unwrap();
+
+    assert_eq!(filename, "NoEmDash.md");
+    assert_eq!(out, content);
+}
+
+#[test]
 fn kebab_case_converts_tax_advisor() {
     assert_eq!(to_kebab_case("TaxAdvisor"), "tax-advisor");
 }

--- a/tests/dotforge.rs
+++ b/tests/dotforge.rs
@@ -130,13 +130,13 @@ fn dotforge_deploys_requested_artifacts_across_providers() {
             "{provider}: unrequested rule must not deploy"
         );
     }
-    // Codex converts skill .md to .toml via agents-to-toml.
+    // Codex skills deploy as SKILL.md; agents-to-toml converts agents only.
     assert!(
         consumer
             .path()
-            .join(".codex/skills/AlphaSkill/SKILL.toml")
+            .join(".codex/skills/AlphaSkill/SKILL.md")
             .is_file(),
-        "codex: AlphaSkill must deploy as .toml"
+        "codex: AlphaSkill must deploy as SKILL.md"
     );
 }
 

--- a/tests/prune.rs
+++ b/tests/prune.rs
@@ -165,10 +165,10 @@ fn prune_does_not_match_name_suffix() {
 
 // --- two-pass prune across all providers ---
 
-/// Codex converts skill `.md` files to `.toml` via the `agents-to-toml`
-/// assembly rule. Every other provider keeps the `.md` extension.
-fn skill_file_extension(provider: &str) -> &'static str {
-    if provider == ".codex" { "toml" } else { "md" }
+/// Skills deploy as `SKILL.md` for every provider, Codex included; only agents
+/// are converted to TOML (`agents-to-toml` is gated to `kind == "agents"`).
+fn skill_file_extension(_provider: &str) -> &'static str {
+    "md"
 }
 
 fn run_two_pass_prune_for_provider(provider: &str) {


### PR DESCRIPTION
Codex reads custom skills as `SKILL.md` markdown, but forge deployed them as `SKILL.toml`, so Codex silently ignored every forge-installed skill. The `agents-to-toml` rule converted agents, skills, and rules alike. Only Codex *agents* are TOML (`~/.codex/agents/*.toml`); skills and rules are markdown. The README rule table already documented `agents-to-toml` as "agents only", but the code never enforced it.

## Fix

Guard `AssemblyRule::AgentsToToml` on `kind == "agents"`, the guard `KebabCaseAgents` already carries. Skills and rules now deploy as markdown for every provider; agents still convert to TOML for Codex.

## Test plan

- [x] `cargo test`: 3 new unit tests (agent to `.toml`, skill to `.md`, rule to `.md`) plus two integration tests corrected off the old `SKILL.toml` assumption
- [x] `cargo clippy` clean
- [x] Re-deployed Codex from source: `~/.codex/skills/` is `SKILL.md`, `~/.codex/agents/` still `.toml`
