### PR TITLE
fix: preserve Claude-native skill frontmatter through assembly (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - `forge install` and `forge deploy` default `--target` to `--source` when a `.forge` consumer manifest is present and `--target` is omitted. The consumer dir IS the place the user wants provider trees written; the previous behavior forced redundant `--target .` on every consumer-mode invocation. Module-root flows (no `.forge`) are unchanged: an omitted `--target` still resolves provider directories relative to the current working directory. (#52)
 
+### Fixed
+
+- Assembly preserves Claude-native `SKILL.md` frontmatter for the claude provider. `claude.keep_fields.skills` previously kept only `name`, `description`, and `version`, so `forge assemble` stripped `allowed-tools` (and the rest of the Claude Code optional skill fields) from deployed skills, breaking tool pre-approval and gating dynamic context injection (`!` command lines). The claude skill keep-list now mirrors the skill mdschema whitelist (`allowed-tools`, `argument-hint`, `arguments`, `disable-model-invocation`, `user-invocable`, `model`, `effort`, `context`, `agent`, `paths`, `shell`). The frontmatter stripper also retains multi-line block values for kept fields, so a list-form `allowed-tools:` survives intact instead of collapsing to a valueless key. (#69)
+
 ## [0.3.2] - 2026-05-22
 
 ### Fixed

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -23,7 +23,26 @@ providers:
             - claudecode
         keep_fields:
             agents: [name, description, model, allowedTools]
-            skills: [name, description, version]
+            # Claude Code reads these SKILL.md fields natively; stripping any
+            # of them breaks the deployed skill (allowed-tools gates tool
+            # pre-approval and dynamic context injection). Mirrors the skill
+            # mdschema whitelist.
+            skills:
+                - name
+                - description
+                - version
+                - when_to_use
+                - argument-hint
+                - arguments
+                - allowed-tools
+                - disable-model-invocation
+                - user-invocable
+                - model
+                - effort
+                - context
+                - agent
+                - paths
+                - shell
             rules: []
         models:
             strong: [opus]

--- a/src/assemble/frontmatter.rs
+++ b/src/assemble/frontmatter.rs
@@ -18,25 +18,20 @@ pub fn strip_frontmatter(content: &str, keep_fields: &[&str]) -> String {
     }
 
     let mut kept_lines: Vec<&str> = Vec::new();
+    let mut keep_current_block = false;
     for line in yaml_text.lines() {
-        let Some(colon_pos) = line.find(':') else {
-            continue;
-        };
-        let key = &line[..colon_pos];
-        let is_valid_key = key
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.');
-        if !is_valid_key {
-            continue;
-        }
-        let mut matched = false;
-        for field in keep_fields {
-            if key.eq_ignore_ascii_case(field) {
-                matched = true;
-                break;
+        if let Some(key) = top_level_key(line) {
+            keep_current_block = keep_fields
+                .iter()
+                .any(|field| key.eq_ignore_ascii_case(field));
+            if keep_current_block {
+                kept_lines.push(line);
             }
-        }
-        if matched {
+        } else if keep_current_block {
+            // Continuation of a kept key: a block scalar, list item, or
+            // nested mapping value. Retaining it keeps multi-line values
+            // (e.g. an `allowed-tools:` list) intact instead of collapsing
+            // them to a bare key with no value.
             kept_lines.push(line);
         }
     }
@@ -115,6 +110,25 @@ pub fn set_field(content: &str, target_field: &str, value: &str) -> String {
     };
 
     format!("---\n{new_yaml}---\n{body}")
+}
+
+/// Return the key of a top-level YAML mapping line — one with no leading
+/// indentation and a valid `key:` prefix. Indented continuation lines, list
+/// items (`- ...`), comments, and blanks return `None`, marking them as part
+/// of the preceding key's value rather than a new key.
+fn top_level_key(line: &str) -> Option<&str> {
+    if line.starts_with([' ', '\t']) {
+        return None;
+    }
+    let colon_pos = line.find(':')?;
+    let key = &line[..colon_pos];
+    if key.is_empty() {
+        return None;
+    }
+    let is_valid_key = key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.');
+    is_valid_key.then_some(key)
 }
 
 /// Strip a leading `# Title` heading if it's the first non-empty line.

--- a/src/assemble/tests.rs
+++ b/src/assemble/tests.rs
@@ -90,6 +90,50 @@ fn strip_frontmatter_keeps_specified_fields_case_insensitively() {
 }
 
 #[test]
+fn strip_frontmatter_preserves_block_list_value() {
+    let content = concat!(
+        "---\n",
+        "name: Foo\n",
+        "allowed-tools:\n",
+        "    - Bash(pass *)\n",
+        "    - Read\n",
+        "sources: forge-core\n",
+        "---\n",
+        "Body.\n",
+    );
+    let result = strip_frontmatter(content, &["name", "allowed-tools"]);
+    assert!(result.contains("allowed-tools:"), "key line kept");
+    assert!(
+        result.contains("- Bash(pass *)"),
+        "first list item must survive: {result}"
+    );
+    assert!(result.contains("- Read"), "second list item must survive");
+    assert!(!result.contains("sources:"), "unlisted key dropped");
+}
+
+#[test]
+fn strip_frontmatter_block_value_of_dropped_key_does_not_leak() {
+    let content = concat!(
+        "---\n",
+        "name: Foo\n",
+        "sources:\n",
+        "    - forge-core\n",
+        "    - forge-dev\n",
+        "version: 0.1.0\n",
+        "---\n",
+        "Body.\n",
+    );
+    let result = strip_frontmatter(content, &["name", "version"]);
+    assert!(result.contains("name: Foo"));
+    assert!(result.contains("version: 0.1.0"));
+    assert!(!result.contains("sources:"), "dropped key gone");
+    assert!(
+        !result.contains("forge-dev"),
+        "dropped key's list items must not leak: {result}"
+    );
+}
+
+#[test]
 fn map_field_finds_name_after_other_fields() {
     let content = "---\ndescription: test\nname: TestAgent\n---";
     let result = map_field(content, "name", |v| v.to_lowercase());

--- a/tests/deploy.rs
+++ b/tests/deploy.rs
@@ -77,6 +77,18 @@ fn create_skill_with_companion(root: &Path, name: &str, companion: &str) {
     .unwrap();
 }
 
+fn create_skill_with_claude_fields(root: &Path, name: &str) {
+    let skill_dir = root.join("skills").join(name);
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        format!(
+            "---\nname: {name}\ndescription: test skill\nversion: 1.0.0\nargument-hint: <path>\nallowed-tools:\n    - Bash(pass *)\n    - Read\nsources: forge-core\n---\n\nSkill instructions.\n"
+        ),
+    )
+    .unwrap();
+}
+
 // --- Install tests ---
 
 #[test]
@@ -121,6 +133,62 @@ fn install_deploys_agent_to_all_providers() {
             .path()
             .join(".opencode/agents/test-agent.md")
             .is_file()
+    );
+}
+
+#[test]
+fn install_preserves_claude_skill_allowed_tools() {
+    let module_directory = tempfile::tempdir().unwrap();
+    let target_directory = tempfile::tempdir().unwrap();
+
+    scaffold_module(module_directory.path());
+    create_skill_with_claude_fields(module_directory.path(), "DciSkill");
+
+    forge()
+        .args([
+            "install",
+            "--source",
+            module_directory.path().to_str().unwrap(),
+            "--target",
+            target_directory.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let claude_skill = fs::read_to_string(
+        target_directory
+            .path()
+            .join(".claude/skills/DciSkill/SKILL.md"),
+    )
+    .unwrap();
+    assert!(
+        claude_skill.contains("allowed-tools:"),
+        "claude must keep the allowed-tools key: {claude_skill}"
+    );
+    assert!(
+        claude_skill.contains("- Bash(pass *)") && claude_skill.contains("- Read"),
+        "claude must keep every allowed-tools list item: {claude_skill}"
+    );
+    assert!(
+        claude_skill.contains("argument-hint: <path>"),
+        "claude must keep argument-hint: {claude_skill}"
+    );
+    assert!(
+        !claude_skill.contains("sources:"),
+        "forge-internal sources field must still be stripped: {claude_skill}"
+    );
+
+    // gemini keeps only name/description/version for skills, so the
+    // Claude-native fields must not leak into the gemini deployment.
+    let gemini_skill = fs::read_to_string(
+        target_directory
+            .path()
+            .join(".gemini/skills/DciSkill/SKILL.md"),
+    )
+    .unwrap();
+    assert!(
+        !gemini_skill.contains("allowed-tools:"),
+        "gemini must not carry Claude-native allowed-tools: {gemini_skill}"
     );
 }
 


### PR DESCRIPTION
Closes #69.

## Problem

`forge assemble` dropped `allowed-tools` from `SKILL.md` for the Claude provider. `claude.keep_fields.skills` kept only `name`, `description`, and `version`, so every other Claude Code optional skill field was stripped during assembly. A deployed skill lost its tool pre-approval, and dynamic context injection (`!` command lines) was gated because `allowed-tools` no longer survived.

## Fix

The Claude skill keep-list now mirrors the skill mdschema whitelist: `allowed-tools`, `argument-hint`, `arguments`, `disable-model-invocation`, `user-invocable`, `model`, `effort`, `context`, `agent`, `paths`, `shell` (plus `name`/`description`/`version`). The frontmatter stripper also retains multi-line block values for kept fields, so a list-form `allowed-tools:` survives intact instead of collapsing to a valueless key.

## Out of scope

Extending the same superset to the gemini/codex/opencode skill keep-lists. Research confirms it is safe (those tools ignore unknown SKILL.md keys), but it is a separate change.

## Test plan

- [x] `cargo test --release` (assemble unit tests + new `install_preserves_claude_skill_allowed_tools` integration test)
- [x] `cargo clippy --release -- -D warnings`
- [x] `cargo fmt --check`