### PR TITLE
feat: validate Claude Code plugin scaffolding in forge validate (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- `forge validate` sanity-checks Claude Code plugin scaffolding when `.claude-plugin/plugin.json` is present: each manifest (`plugin.json`, `.claude-plugin/marketplace.json`, `hooks/hooks.json`) must be valid JSON, and every hook script referenced via `${CLAUDE_PLUGIN_ROOT}` must exist and be executable (the most common cause of hooks silently not firing). It deliberately makes no assertions about the plugin or marketplace field schema, so it does not break when Claude Code's plugin format changes. Non-plugin modules are unaffected: the check runs only when `plugin.json` exists. (#59)
 - `.forge` consumer manifests accept `git:` sources pinned to a 40-hex commit SHA. `forge install` clones the remote via `gix` into a content-addressed cache at `~/.cache/forge/git/<host>/<owner>/<repo>/`, materializes the pinned tree, and feeds it through the standard assemble + deploy pipeline. HTTPS-only; `ssh://`, `git://`, `git@host:` shorthand, and userinfo URLs are rejected at parse time. Branch names, tags, and abbreviated SHAs are rejected in favor of explicit 40-char commit hashes. Cache hits are instant; the bare clone is reused across SHA pins within the same repository. (#53)
 
 ### Changed

--- a/src/cli/validate/mod.rs
+++ b/src/cli/validate/mod.rs
@@ -1,4 +1,5 @@
 mod check;
+mod plugin;
 mod repository;
 mod schema;
 pub(crate) mod templates;
@@ -72,6 +73,8 @@ pub fn execute(path: &str) -> Result<ActionResult, Error> {
             }
         }
     }
+
+    plugin::check_plugin_scaffolding(module_root, &mut result);
 
     tools::run_external_checks(module_root, &mut result);
 

--- a/src/cli/validate/plugin.rs
+++ b/src/cli/validate/plugin.rs
@@ -1,0 +1,111 @@
+use commands::result::ActionResult;
+use commands::validate::{Diagnostic, validate_hooks_manifest, validate_json_manifest};
+use std::fs;
+use std::path::Path;
+
+/// Validate Claude Code plugin scaffolding, if present.
+///
+/// Runs only when `.claude-plugin/plugin.json` exists, so non-plugin modules
+/// are unaffected. Checks the plugin manifest, the optional marketplace
+/// manifest, and `hooks/hooks.json` (including that every referenced hook
+/// script exists and is executable).
+pub fn check_plugin_scaffolding(module_root: &Path, result: &mut ActionResult) {
+    let plugin_manifest = module_root.join(".claude-plugin/plugin.json");
+    if !plugin_manifest.is_file() {
+        return;
+    }
+
+    println!("  claude-plugin scaffolding");
+
+    check_manifest(&plugin_manifest, result, validate_json_manifest);
+
+    let marketplace_manifest = module_root.join(".claude-plugin/marketplace.json");
+    if marketplace_manifest.is_file() {
+        check_manifest(&marketplace_manifest, result, validate_json_manifest);
+    }
+
+    let hooks_manifest = module_root.join("hooks/hooks.json");
+    if hooks_manifest.is_file() {
+        check_hooks(module_root, &hooks_manifest, result);
+    }
+}
+
+fn check_manifest(
+    path: &Path,
+    result: &mut ActionResult,
+    validator: impl Fn(&str, &str) -> Vec<Diagnostic>,
+) {
+    let display_path = path.to_string_lossy().to_string();
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(read_error) => {
+            result
+                .errors
+                .push(format!("{display_path}: cannot read: {read_error}"));
+            return;
+        }
+    };
+    push_diagnostics(validator(&content, &display_path), result);
+}
+
+fn check_hooks(module_root: &Path, hooks_manifest: &Path, result: &mut ActionResult) {
+    let display_path = hooks_manifest.to_string_lossy().to_string();
+    let content = match fs::read_to_string(hooks_manifest) {
+        Ok(content) => content,
+        Err(read_error) => {
+            result
+                .errors
+                .push(format!("{display_path}: cannot read: {read_error}"));
+            return;
+        }
+    };
+
+    let (diagnostics, scripts) = validate_hooks_manifest(&content, &display_path);
+    push_diagnostics(diagnostics, result);
+
+    for script in scripts {
+        check_hook_script(module_root, &display_path, &script, result);
+    }
+}
+
+fn check_hook_script(
+    module_root: &Path,
+    manifest_path: &str,
+    script: &str,
+    result: &mut ActionResult,
+) {
+    let script_path = module_root.join(script);
+    if !script_path.is_file() {
+        result
+            .errors
+            .push(format!("{manifest_path}: hook script not found: {script}"));
+        return;
+    }
+    if !is_executable(&script_path) {
+        result.errors.push(format!(
+            "{manifest_path}: hook script is not executable (chmod +x): {script}"
+        ));
+    }
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(path).is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(_path: &Path) -> bool {
+    // The executable bit is not meaningful on non-unix targets; treat the
+    // script as runnable so validation does not flag a phantom problem.
+    true
+}
+
+fn push_diagnostics(diagnostics: Vec<Diagnostic>, result: &mut ActionResult) {
+    for diagnostic in diagnostics {
+        result.errors.push(format!(
+            "{}: {} ({:?})",
+            diagnostic.file, diagnostic.message, diagnostic.severity
+        ));
+    }
+}

--- a/src/cli/validate/tests.rs
+++ b/src/cli/validate/tests.rs
@@ -108,3 +108,106 @@ fn is_excluded_matches_exact_path() {
     let patterns = vec!["defaults.yaml".to_string()];
     assert!(tools::is_excluded(file_path, module_root, &patterns));
 }
+
+// --- plugin scaffolding (CLI orchestration) ---
+
+fn write_plugin_manifest(root: &std::path::Path, body: &str) {
+    let dir = root.join(".claude-plugin");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("plugin.json"), body).unwrap();
+}
+
+fn write_hook_script(root: &std::path::Path, relative: &str, executable: bool) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "#!/bin/sh\necho hi\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = if executable { 0o755 } else { 0o644 };
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).unwrap();
+    }
+    #[cfg(not(unix))]
+    let _ = executable;
+}
+
+#[test]
+fn plugin_scaffolding_skipped_without_manifest() {
+    let temp = TempDir::new().unwrap();
+    let mut result = ActionResult::new();
+    plugin::check_plugin_scaffolding(temp.path(), &mut result);
+    assert!(result.errors.is_empty(), "no plugin, no errors");
+}
+
+#[test]
+fn plugin_scaffolding_valid_tree_passes() {
+    let temp = TempDir::new().unwrap();
+    write_plugin_manifest(temp.path(), r#"{"name": "my-plugin"}"#);
+    std::fs::create_dir_all(temp.path().join("hooks")).unwrap();
+    std::fs::write(
+        temp.path().join("hooks/hooks.json"),
+        r#"{"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh"}]}]}}"#,
+    )
+    .unwrap();
+    write_hook_script(temp.path(), "hooks/guard.sh", true);
+
+    let mut result = ActionResult::new();
+    plugin::check_plugin_scaffolding(temp.path(), &mut result);
+    assert!(result.errors.is_empty(), "valid tree: {:?}", result.errors);
+}
+
+#[test]
+fn plugin_scaffolding_corrupt_manifest_errors() {
+    let temp = TempDir::new().unwrap();
+    write_plugin_manifest(temp.path(), "{ not valid json");
+
+    let mut result = ActionResult::new();
+    plugin::check_plugin_scaffolding(temp.path(), &mut result);
+    assert!(
+        result.errors.iter().any(|e| e.contains("invalid JSON")),
+        "expected JSON error: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn plugin_scaffolding_missing_hook_script_errors() {
+    let temp = TempDir::new().unwrap();
+    write_plugin_manifest(temp.path(), r#"{"name": "p"}"#);
+    std::fs::create_dir_all(temp.path().join("hooks")).unwrap();
+    std::fs::write(
+        temp.path().join("hooks/hooks.json"),
+        r#"{"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ghost.sh"}]}]}}"#,
+    )
+    .unwrap();
+
+    let mut result = ActionResult::new();
+    plugin::check_plugin_scaffolding(temp.path(), &mut result);
+    assert!(
+        result.errors.iter().any(|e| e.contains("not found")),
+        "expected missing-script error: {:?}",
+        result.errors
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn plugin_scaffolding_non_executable_hook_errors() {
+    let temp = TempDir::new().unwrap();
+    write_plugin_manifest(temp.path(), r#"{"name": "p"}"#);
+    std::fs::create_dir_all(temp.path().join("hooks")).unwrap();
+    std::fs::write(
+        temp.path().join("hooks/hooks.json"),
+        r#"{"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh"}]}]}}"#,
+    )
+    .unwrap();
+    write_hook_script(temp.path(), "hooks/guard.sh", false);
+
+    let mut result = ActionResult::new();
+    plugin::check_plugin_scaffolding(temp.path(), &mut result);
+    assert!(
+        result.errors.iter().any(|e| e.contains("not executable")),
+        "expected non-executable error: {:?}",
+        result.errors
+    );
+}

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -4,10 +4,12 @@ mod agent;
 mod frontmatter;
 pub mod json_schema;
 pub mod mdschema;
+mod plugin;
 
 pub use agent::validate;
 pub use frontmatter::validate_frontmatter;
 pub use json_schema::validate_frontmatter_against_json_schema;
+pub use plugin::{validate_hooks_manifest, validate_json_manifest};
 
 // --- Types ---
 

--- a/src/validate/plugin.rs
+++ b/src/validate/plugin.rs
@@ -1,0 +1,98 @@
+//! Format-resilient checks for Claude Code plugin scaffolding.
+//!
+//! Deliberately schema-light: it confirms each manifest is valid JSON and
+//! returns the hook scripts referenced via `${CLAUDE_PLUGIN_ROOT}` so the CLI
+//! can check they exist and are executable (the most common "hooks don't fire"
+//! cause). It does NOT assert the plugin/marketplace field shape, so it does
+//! not break when Claude Code's plugin schema changes.
+
+use crate::validate::{Diagnostic, Severity};
+use regex::Regex;
+use serde_json::Value;
+use std::sync::OnceLock;
+
+fn error(file: &str, message: String) -> Diagnostic {
+    Diagnostic {
+        file: file.to_string(),
+        line: None,
+        severity: Severity::Error,
+        message,
+    }
+}
+
+/// Confirm a plugin manifest (`plugin.json` or `marketplace.json`) is valid
+/// JSON. No field-shape assertions: a corrupt manifest is the failure mode
+/// worth catching, and the schema is Claude Code's to define.
+pub fn validate_json_manifest(content: &str, file: &str) -> Vec<Diagnostic> {
+    match serde_json::from_str::<Value>(content) {
+        Ok(_) => Vec::new(),
+        Err(parse_error) => vec![error(file, format!("invalid JSON: {parse_error}"))],
+    }
+}
+
+/// Confirm `hooks/hooks.json` is valid JSON and return the hook script paths it
+/// references via `${CLAUDE_PLUGIN_ROOT}/<path>`, for the CLI to check for
+/// existence and the executable bit. Commands that do not use the
+/// `${CLAUDE_PLUGIN_ROOT}` convention are left alone — the check is
+/// opportunistic, not an assertion about command shape.
+pub fn validate_hooks_manifest(content: &str, file: &str) -> (Vec<Diagnostic>, Vec<String>) {
+    let parsed: Value = match serde_json::from_str(content) {
+        Ok(value) => value,
+        Err(parse_error) => {
+            return (
+                vec![error(file, format!("invalid JSON: {parse_error}"))],
+                Vec::new(),
+            );
+        }
+    };
+
+    let scripts = collect_commands(&parsed)
+        .iter()
+        .filter_map(|command| extract_script_path(command))
+        .collect();
+
+    (Vec::new(), scripts)
+}
+
+/// Collect every string under a `command` key anywhere in the JSON tree.
+/// `hooks.json` nests commands under `hooks` → event → matcher groups, so a
+/// recursive sweep reaches them without hard-coding the event names.
+fn collect_commands(value: &Value) -> Vec<String> {
+    let mut commands = Vec::new();
+    walk_commands(value, &mut commands);
+    commands
+}
+
+fn walk_commands(value: &Value, commands: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if key == "command"
+                    && let Value::String(command) = child
+                {
+                    commands.push(command.clone());
+                }
+                walk_commands(child, commands);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                walk_commands(item, commands);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Extract the script path that follows `${CLAUDE_PLUGIN_ROOT}/` in a command,
+/// or `None` if the command does not use the convention.
+fn extract_script_path(command: &str) -> Option<String> {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    let regex = PATTERN.get_or_init(|| {
+        Regex::new(r#"\$\{CLAUDE_PLUGIN_ROOT\}/([^"\s]+)"#).expect("static plugin-root regex")
+    });
+    regex
+        .captures(command)
+        .and_then(|capture| capture.get(1))
+        .map(|matched| matched.as_str().to_string())
+}

--- a/src/validate/tests.rs
+++ b/src/validate/tests.rs
@@ -252,3 +252,73 @@ fn adr_mdschema_catches_missing_section() {
         "expected missing 'Considered Options' diagnostic"
     );
 }
+
+// --- plugin scaffolding validators (schema-light) ---
+
+#[test]
+fn json_manifest_valid_passes() {
+    let content = r#"{"name": "my-plugin", "anything": ["here"]}"#;
+    let diagnostics = validate_json_manifest(content, ".claude-plugin/plugin.json");
+    assert!(diagnostics.is_empty(), "valid JSON: {diagnostics:?}");
+}
+
+#[test]
+fn json_manifest_invalid_errors() {
+    let diagnostics = validate_json_manifest("{not json", "plugin.json");
+    assert_eq!(diagnostics.len(), 1);
+    assert!(diagnostics[0].message.contains("invalid JSON"));
+    assert_eq!(diagnostics[0].severity, Severity::Error);
+}
+
+#[test]
+fn json_manifest_does_not_assert_field_shape() {
+    // No name, non-kebab fields, arbitrary shape: as long as it parses, it passes.
+    // The schema is Claude Code's to define, not ours to police.
+    let content = r#"{"OWNER": "Whatever", "plugins": []}"#;
+    let diagnostics = validate_json_manifest(content, "marketplace.json");
+    assert!(
+        diagnostics.is_empty(),
+        "shape is not asserted: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn hooks_manifest_invalid_json_errors() {
+    let (diagnostics, scripts) = validate_hooks_manifest("{bad", "hooks.json");
+    assert_eq!(diagnostics.len(), 1);
+    assert!(diagnostics[0].message.contains("invalid JSON"));
+    assert!(scripts.is_empty());
+}
+
+#[test]
+fn hooks_manifest_extracts_plugin_root_script() {
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {"hooks": [{"type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh --flag"}]}
+            ]
+        }
+    }"#;
+    let (diagnostics, scripts) = validate_hooks_manifest(content, "hooks.json");
+    assert!(diagnostics.is_empty(), "valid hooks JSON: {diagnostics:?}");
+    assert_eq!(scripts, vec!["hooks/guard.sh".to_string()]);
+}
+
+#[test]
+fn hooks_manifest_ignores_non_convention_command() {
+    // A command that does not use ${CLAUDE_PLUGIN_ROOT} is not an error; it
+    // simply yields no script to check.
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {"hooks": [{"type": "command", "command": "/usr/bin/foo.sh"}]}
+            ]
+        }
+    }"#;
+    let (diagnostics, scripts) = validate_hooks_manifest(content, "hooks.json");
+    assert!(
+        diagnostics.is_empty(),
+        "non-convention command is not flagged"
+    );
+    assert!(scripts.is_empty());
+}


### PR DESCRIPTION
Closes #59.

## Problem

`forge validate` had no awareness of Claude Code plugin scaffolding, so a corrupt `.claude-plugin/plugin.json`, a renamed-but-missing hook script, or a hook script committed without `chmod +x` (the most common cause of hooks silently not firing) all shipped undetected and only surfaced at install time.

## Approach

A schema-light check that runs only when `.claude-plugin/plugin.json` exists. It confirms each manifest (`plugin.json`, `marketplace.json`, `hooks/hooks.json`) is valid JSON, and that every hook script referenced via `${CLAUDE_PLUGIN_ROOT}` exists and is executable. It deliberately makes **no assertions about the plugin or marketplace field schema** (required fields, kebab-case names, `owner.name`, `plugins[]` shape) — that schema is Claude Code's to define, so coupling to it would be a maintenance liability that breaks on format drift. The pure JSON-and-files checks survive schema changes.

## Out of scope

Any plugin/marketplace field-shape validation, validating skill/agent/hook content (already covered by mdschema + frontmatter), and running the hooks.

## Test plan

- [x] `cargo test --release` (lib: JSON-valid / JSON-invalid / shape-not-asserted / hook-script extraction + non-convention-ignored; CLI: valid tree, corrupt manifest, missing script, non-executable script)
- [x] `cargo clippy --release -- -D warnings`
- [x] `cargo fmt --check`