### PR TITLE
feat: attest release tarballs with build provenance

### DIFF
--- a/.github/workflows/module-release.yaml
+++ b/.github/workflows/module-release.yaml
@@ -10,6 +10,8 @@ on:
 
 permissions:
     contents: write
+    id-token: write
+    attestations: write
 
 jobs:
     release:
@@ -26,6 +28,11 @@ jobs:
 
             - name: Release
               run: forge release
+
+            - name: Attest build provenance
+              uses: actions/attest-build-provenance@v4
+              with:
+                  subject-path: build/*.tar.gz
 
             - name: Create GitHub release
               env:

--- a/.specstory/.project.json
+++ b/.specstory/.project.json
@@ -1,0 +1,7 @@
+{
+  "workspace_id": "6730-3607-3022-91ee",
+  "workspace_id_at": "2026-06-23T20:10:10Z",
+  "git_id": "3abe-a224-929e-b796",
+  "git_id_at": "2026-06-23T20:10:10Z",
+  "project_name": "forge-cli"
+}

--- a/.specstory/cli/config.toml
+++ b/.specstory/cli/config.toml
@@ -1,0 +1,82 @@
+# SpecStory CLI Configuration
+#
+# This is the project-level config file for SpecStory CLI.
+# All settings here apply to this project unless overridden by CLI flags.
+#
+# Uncomment (remove the #) the line and edit any setting below to change the default behavior.
+# For more information, see: https://docs.specstory.com/integrations/terminal-coding-agents/usage
+
+[local_sync]
+# Write markdown files locally. (default: true)
+# enabled = false # equivalent to --only-cloud-sync
+
+# Custom output directory for markdown files.
+# Default: ./.specstory/history (relative to the project directory)
+# output_dir = "~/.specstory/history" # equivalent to --output-dir "~/.specstory/history"
+
+# Use local timezone for file name and content timestamps (default: false, UTC)
+# local_time_zone = true # equivalent to --local-time-zone
+
+[cloud_sync]
+# Sync session data to SpecStory Cloud. (default: true, when logged in to SpecStory Cloud)
+# enabled = false # equivalent to --no-cloud-sync
+
+[logging]
+# Write logs to .specstory/debug/debug.log (default: false)
+# log = true # equivalent to --log
+
+# Debug-level output, requires console or log (default: false)
+# debug = true # equivalent to --debug
+
+# Custom output directory for debug data.
+# Default: ./.specstory/debug (relative to the project directory)
+# debug_dir = "~/.specstory/debug" # equivalent to --debug-dir "~/.specstory/debug"
+
+# Error/warn/info output to stdout (default: false)
+# console = true # equivalent to --console
+
+# Suppress all non-error output (default: false)
+# silent = true	# equivalent to --silent
+
+[version_check]
+# Check for new versions of the CLI on startup.
+# Default: true
+# enabled = false # equivalent to --no-version-check
+
+[analytics]
+# Send anonymous product usage analytics to help improve SpecStory.
+# Default: true
+# enabled = false # equivalent to --no-usage-analytics
+
+[telemetry]
+# OTLP gRPC collector endpoint (e.g., "localhost:4317" or "http://localhost:4317")
+# endpoint = "localhost:4317"
+
+# Override the default service name (default: "specstory-cli")
+# service_name = "my-service-name"
+
+# Include user prompt text in telemetry spans (default: true)
+# prompts = false
+
+[providers]
+# Agent execution commands by provider (used by specstory run)
+# Pass custom flags (e.g. claude_cmd = "claude --allow-dangerously-skip-permissions")
+# Use of these is equivalent to -c "custom command"
+
+# Claude Code command
+# claude_cmd = "claude"
+
+# Codex CLI command
+# codex_cmd = "codex"
+
+# Cursor CLI command
+# cursor_cmd = "cursor-agent"
+
+# Droid CLI command
+# droid_cmd = "droid"
+
+# Gemini CLI command
+# gemini_cmd = "gemini"
+
+# DeepSeek TUI command
+# deepseek_cmd = "deepseek"


### PR DESCRIPTION
## Problem

Module release tarballs published through `module-release.yaml` carry no provenance; nothing ties an asset on a GitHub release back to the workflow run and commit that built it.

## Fix

`actions/attest-build-provenance` attests `build/*.tar.gz` after `forge release`, and the workflow declares the `id-token` and `attestations` permissions it needs. Consumers can verify assets with `gh attestation verify`.

Callers must grant the two new permissions in their `release.yaml` job, or the attestation step fails. Modules pinned to `@main` pick this requirement up on their next tag push; modules pinned to a tag (forge-core as of N4M3Z/forge-core#77) adopt it when they bump the pin, so tagging a `v0.3.3` release after this merges gives them a clean target.

## Test plan

- [x] `make validate` green (clippy, tests, semgrep, forge validate, secret scan)
- [ ] Next module tag push produces a release with a verifiable attestation
