### PR TITLE
fix: clippy lints across lib and test targets

### DIFF
--- a/src/assemble/tests.rs
+++ b/src/assemble/tests.rs
@@ -92,7 +92,7 @@ fn strip_frontmatter_keeps_specified_fields_case_insensitively() {
 #[test]
 fn map_field_finds_name_after_other_fields() {
     let content = "---\ndescription: test\nname: TestAgent\n---";
-    let result = map_field(content, "name", |v| v.to_lowercase());
+    let result = map_field(content, "name", str::to_lowercase);
     assert!(result.contains("name: testagent"));
     assert!(result.contains("description: test"));
 }
@@ -100,7 +100,7 @@ fn map_field_finds_name_after_other_fields() {
 #[test]
 fn map_field_handles_double_quoted_value() {
     let content = "---\nname: \"SecurityArchitect\"\n---";
-    let result = map_field(content, "name", |v| v.to_lowercase());
+    let result = map_field(content, "name", str::to_lowercase);
     assert!(
         result.contains("name: securityarchitect"),
         "quoted value should be unwrapped before mapping: {result}"
@@ -110,7 +110,7 @@ fn map_field_handles_double_quoted_value() {
 #[test]
 fn map_field_handles_single_quoted_value() {
     let content = "---\nname: 'SecurityArchitect'\n---";
-    let result = map_field(content, "name", |v| v.to_lowercase());
+    let result = map_field(content, "name", str::to_lowercase);
     assert!(
         result.contains("name: securityarchitect"),
         "single-quoted value should be unwrapped before mapping: {result}"
@@ -120,7 +120,7 @@ fn map_field_handles_single_quoted_value() {
 #[test]
 fn map_field_returns_unchanged_when_field_missing() {
     let content = "---\ndescription: test\n---\nBody.";
-    let result = map_field(content, "name", |v| v.to_lowercase());
+    let result = map_field(content, "name", str::to_lowercase);
     assert_eq!(result, content);
 }
 

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -166,10 +166,7 @@ fn resolve_expression<'yaml>(root: &'yaml Value, expression: &str) -> Option<&'y
     let mut current = root;
 
     for segment in &segments {
-        match current.get(*segment) {
-            Some(next) => current = next,
-            None => return None,
-        }
+        current = current.get(*segment)?;
     }
 
     Some(current)

--- a/tests/drift.rs
+++ b/tests/drift.rs
@@ -206,9 +206,7 @@ fn drift_both_frontmatter_and_body_difference() {
     write_file(
         upstream_directory.path(),
         "rules/Diverged.md",
-        &format!(
-            "---\nname: Diverged\ndescription: different description\nversion: 2.0\n---\n\nUpstream body content.\n"
-        ),
+        "---\nname: Diverged\ndescription: different description\nversion: 2.0\n---\n\nUpstream body content.\n",
     );
 
     let output = forge()
@@ -745,12 +743,12 @@ fn ignore_both_frontmatter_and_body() {
     write_file(
         module_directory.path(),
         "rules/TestRule.md",
-        &format!("---\nname: TestRule\nproject: local\n---\n\nLocal body.\n"),
+        "---\nname: TestRule\nproject: local\n---\n\nLocal body.\n",
     );
     write_file(
         upstream_directory.path(),
         "rules/TestRule.md",
-        &format!("---\nname: TestRule\nproject: upstream\n---\n\nUpstream body.\n"),
+        "---\nname: TestRule\nproject: upstream\n---\n\nUpstream body.\n",
     );
 
     let output = forge()
@@ -782,12 +780,12 @@ fn ignore_body_on_both_drift_keeps_frontmatter() {
     write_file(
         module_directory.path(),
         "rules/TestRule.md",
-        &format!("---\nname: TestRule\nversion: 2.0\n---\n\nLocal body.\n"),
+        "---\nname: TestRule\nversion: 2.0\n---\n\nLocal body.\n",
     );
     write_file(
         upstream_directory.path(),
         "rules/TestRule.md",
-        &format!("---\nname: TestRule\nversion: 1.0\n---\n\nUpstream body.\n"),
+        "---\nname: TestRule\nversion: 1.0\n---\n\nUpstream body.\n",
     );
 
     let output = forge()

--- a/tests/prune.rs
+++ b/tests/prune.rs
@@ -237,8 +237,7 @@ fn run_two_pass_prune_for_provider(provider: &str) {
     assert_eq!(
         trash_entries.len(),
         1,
-        "{provider}: exactly one timestamped trash entry expected, found {:?}",
-        trash_entries
+        "{provider}: exactly one timestamped trash entry expected, found {trash_entries:?}"
     );
     let trash_dir = &trash_entries[0];
     assert!(


### PR DESCRIPTION
## Problem

CI fails on every PR: the runners' Rust 1.97 clippy added `question_mark` (fires in `src/yaml/mod.rs`) and stricter format lints in test targets, all denied under `-D warnings`. forge-cli#84 is red through no fault of its diff.

## Fix

Apply the machine-suggested rewrites: `?` instead of the `match` in the yaml path walker, string literals instead of argument-less `format!`, inlined format args, and a method reference instead of a redundant closure. No behavior change.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` green (478 tests)
- [x] `cargo fmt` applied, prek gate green, tree secret scan clean
