### PR TITLE
fix: drop redundant borrows in println arguments

### DIFF
--- a/src/cli/drift/mod.rs
+++ b/src/cli/drift/mod.rs
@@ -604,7 +604,7 @@ fn print_drift_entry(entry: &DriftEntry) {
             println!(
                 "   {} {} {} {}{}",
                 cyan.apply_to("●"),
-                &entry.name,
+                entry.name,
                 dim.apply_to("—"),
                 cyan.apply_to("local only"),
                 lineage,
@@ -649,7 +649,7 @@ fn print_drift_card(entry: &DriftEntry, lineage: &str) {
     );
     let body_drifted = matches!(entry.status, DriftStatus::BodyOnly | DriftStatus::Both);
 
-    println!("   {} {}{}", dim.apply_to("┌"), &entry.name, lineage);
+    println!("   {} {}{}", dim.apply_to("┌"), entry.name, lineage);
 
     if frontmatter_drifted {
         let keys_display = if entry.changed_keys.is_empty() {

--- a/src/cli/provenance/mod.rs
+++ b/src/cli/provenance/mod.rs
@@ -77,13 +77,13 @@ pub fn execute(
         " {}  {}    {}",
         dim.apply_to("│"),
         dim.apply_to("built"),
-        &details.metadata.started_on
+        details.metadata.started_on
     );
     println!(
         " {}  {}  {} {}",
         dim.apply_to("│"),
         dim.apply_to("builder"),
-        &details.builder.id,
+        details.builder.id,
         dim.apply_to(&details.builder.version.forge)
     );
     println!(" {}", dim.apply_to("│"));
@@ -94,7 +94,7 @@ pub fn execute(
             " {}  {} {} {}",
             dim.apply_to("│"),
             dim.apply_to("input"),
-            &dependency.uri,
+            dependency.uri,
             dim.apply_to(format!("sha256:{short}"))
         );
     }

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -166,10 +166,7 @@ fn resolve_expression<'yaml>(root: &'yaml Value, expression: &str) -> Option<&'y
     let mut current = root;
 
     for segment in &segments {
-        match current.get(*segment) {
-            Some(next) => current = next,
-            None => return None,
-        }
+        current = current.get(*segment)?;
     }
 
     Some(current)


### PR DESCRIPTION
## Problem

Every PR's lint job fails since CI moved to rustc 1.97.0: clippy denies `redundant reference in println! argument` at five call sites in `src/cli/drift/mod.rs` and `src/cli/provenance/mod.rs`, plus the pre-existing `match`-instead-of-`?` at `src/yaml/mod.rs:169`, all on main. Merge-preview builds exit with code 101 regardless of branch content.

## Fix

Drop the redundant `&` at the five flagged arguments and replace the yaml path-lookup `match` with `?`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --all-features` (638 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)